### PR TITLE
test: add ka9q-radio Docker environment for firmware compat testing

### DIFF
--- a/docker/ka9q-radio/Dockerfile
+++ b/docker/ka9q-radio/Dockerfile
@@ -1,0 +1,99 @@
+# ka9q-radio test environment for RX888mk2 firmware validation
+#
+# Build:   docker build -t ka9q-radio docker/ka9q-radio/
+# Run:     docker run --rm -it --privileged -v /dev/bus/usb:/dev/bus/usb \
+#            --network host ka9q-radio
+#
+# The --privileged flag is needed because the FX3 changes USB PID during
+# firmware upload (0x00F3 -> 0x00F1), which changes the device path.
+# --network host is needed for ka9q-radio's multicast UDP output.
+
+FROM debian:bookworm-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    ca-certificates \
+    libavahi-client-dev \
+    libbsd-dev \
+    libfftw3-dev \
+    libiniparser-dev \
+    libncurses-dev \
+    libopus-dev \
+    libusb-1.0-0-dev \
+    libusb-dev \
+    uuid-dev \
+    libogg-dev \
+    libsamplerate-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone ka9q-radio — only need radiod + rx888 plugin
+WORKDIR /build
+RUN git clone --depth 1 https://github.com/ka9q/ka9q-radio.git
+
+WORKDIR /build/ka9q-radio
+
+# Build only what we need: radiod core + rx888.so plugin + control utility
+# Disable all other SDR hardware to avoid pulling in unnecessary -dev packages
+RUN make -C src -j$(nproc) \
+    ENABLE_AIRSPY=0 \
+    ENABLE_AIRSPYHF=0 \
+    ENABLE_BLADERF=0 \
+    ENABLE_FOBOS=0 \
+    ENABLE_FUNCUBE=0 \
+    ENABLE_HACKRF=0 \
+    ENABLE_HYDRASDR=0 \
+    ENABLE_RTLSDR=0 \
+    ENABLE_RX888=1 \
+    ENABLE_SDRPLAY=0 \
+    ENABLE_SIG_GEN=1 \
+    ARCHOPTS="" \
+    radiod rx888.so control tune monitor
+
+# ---- Runtime image ----
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libavahi-client3 \
+    libbsd0 \
+    libfftw3-single3 \
+    libiniparser1 \
+    libncursesw6 \
+    libopus0 \
+    libusb-1.0-0 \
+    libogg0 \
+    libsamplerate0 \
+    avahi-daemon \
+    dbus \
+    procps \
+    usbutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy built binaries
+COPY --from=builder /build/ka9q-radio/src/radiod /usr/local/bin/
+COPY --from=builder /build/ka9q-radio/src/control /usr/local/bin/
+COPY --from=builder /build/ka9q-radio/src/tune /usr/local/bin/
+COPY --from=builder /build/ka9q-radio/src/monitor /usr/local/bin/
+COPY --from=builder /build/ka9q-radio/src/rx888.so /usr/local/lib/ka9q-radio/
+COPY --from=builder /build/ka9q-radio/src/sig_gen.so /usr/local/lib/ka9q-radio/
+
+# Create plugin directory and config directory
+RUN mkdir -p /usr/local/lib/ka9q-radio /etc/radio /var/lib/ka9q-radio
+
+# Install minimal rx888 config for HF direct-sampling test
+COPY rx888-test.conf /etc/radio/radiod@rx888-test.conf
+
+# Copy firmware image if present (can also bind-mount at runtime)
+# The SDDC_FX3.img goes in the working directory or /usr/local/share/ka9q-radio/
+RUN mkdir -p /usr/local/share/ka9q-radio
+
+# Copy entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["radiod", "-f", "/etc/radio/radiod@rx888-test.conf"]

--- a/docker/ka9q-radio/README.md
+++ b/docker/ka9q-radio/README.md
@@ -1,0 +1,84 @@
+# ka9q-radio Docker Test Environment
+
+Docker container for testing SDDC_FX3 firmware compatibility with
+[ka9q-radio](https://github.com/ka9q/ka9q-radio)'s `radiod` and the
+`rx888.so` driver plugin.
+
+## Build
+
+```
+docker build -t ka9q-radio docker/ka9q-radio/
+```
+
+## Run
+
+### With firmware already loaded on the device
+
+```
+docker run --rm -it --privileged \
+  -v /dev/bus/usb:/dev/bus/usb \
+  --network host \
+  ka9q-radio
+```
+
+### With firmware upload (radiod handles it)
+
+```
+docker run --rm -it --privileged \
+  -v /dev/bus/usb:/dev/bus/usb \
+  -v $(pwd)/SDDC_FX3:/firmware \
+  --network host \
+  ka9q-radio
+```
+
+### Interactive shell (for debugging)
+
+```
+docker run --rm -it --privileged \
+  -v /dev/bus/usb:/dev/bus/usb \
+  -v $(pwd)/SDDC_FX3:/firmware \
+  --network host \
+  ka9q-radio bash
+```
+
+Then inside the container:
+
+```
+# Check USB device
+lsusb -d 04b4:
+
+# Run radiod manually
+radiod -f /etc/radio/radiod@rx888-test.conf
+
+# In another terminal (docker exec):
+# Tune to a frequency
+tune hf.local 14.074m
+
+# Monitor status
+monitor hf.local
+```
+
+## What this tests
+
+1. **Firmware upload** — ka9q-radio uses its own `ezusb.c` loader
+   (same protocol as `rx888_stream -f`)
+2. **Si5351 clock programming** — ka9q programs the Si5351 directly
+   via `I2CWFX3` (bypasses firmware `STARTADC`)
+3. **GPIF streaming** — `STARTFX3` + async bulk transfers at 64.8 MSPS
+4. **GPIO control** — `GPIOFX3` for dither, randomizer, HF/VHF select
+5. **Attenuator/VGA** — `SETARGFX3` with DAT31_ATT and AD8340_VGA
+6. **Stop/restart** — `STOPFX3` + `STARTFX3` cycling
+
+## Known compatibility notes
+
+See the analysis in the parent repository for details on:
+
+- `TUNERSTDBY` (0xB8) calls that produce harmless STALLs (ka9q-side fix)
+- GPIO LED bit mapping differences (cosmetic)
+- Missing `libusb_clear_halt()` in ka9q (xHCI fix needed upstream)
+
+## Requirements
+
+- Docker with `--privileged` support
+- RX888mk2 connected via USB 3.0
+- Host kernel with xHCI/USB 3.0 support (any modern Linux)

--- a/docker/ka9q-radio/entrypoint.sh
+++ b/docker/ka9q-radio/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Start dbus (required by avahi)
+if [ ! -d /run/dbus ]; then
+    mkdir -p /run/dbus
+fi
+dbus-daemon --system --nofork &
+sleep 0.5
+
+# Start avahi (required by ka9q-radio for multicast service discovery)
+avahi-daemon --no-drop-root --daemonize 2>/dev/null || true
+
+# Check for firmware image
+if [ ! -f /firmware/SDDC_FX3.img ]; then
+    echo "WARNING: /firmware/SDDC_FX3.img not found."
+    echo "Mount it with: -v /path/to/SDDC_FX3:/firmware"
+    echo "If the device is already loaded, this is fine."
+fi
+
+# Check for USB device
+if lsusb -d 04b4:00f1 > /dev/null 2>&1; then
+    echo "RX888 found (loaded, PID 0x00F1)"
+elif lsusb -d 04b4:00f3 > /dev/null 2>&1; then
+    echo "RX888 found (bootloader, PID 0x00F3) — radiod will upload firmware"
+else
+    echo "WARNING: No RX888 detected on USB bus"
+    echo "Make sure to run with: --privileged -v /dev/bus/usb:/dev/bus/usb"
+fi
+
+exec "$@"

--- a/docker/ka9q-radio/rx888-test.conf
+++ b/docker/ka9q-radio/rx888-test.conf
@@ -1,0 +1,23 @@
+# Minimal ka9q-radio config for RX888mk2 firmware compatibility testing
+# Usage: radiod -f /etc/radio/radiod@rx888-test.conf
+
+[global]
+hardware = rx888
+status = hf.local
+samprate = 12k
+mode = usb
+
+[rx888]
+device = "rx888"
+description = "rx888 firmware test"
+samprate = 64m8
+gain = 10
+dither = no
+rand = no
+firmware = /firmware/SDDC_FX3.img
+
+# Tune to WWV 10 MHz as a quick sanity check
+[WWV]
+data = wwv-pcm.local
+mode = am
+freq = "5000k 10000k 15000k"


### PR DESCRIPTION
Containerized build of ka9q-radio's radiod + rx888.so plugin for validating SDDC_FX3 firmware against the primary Linux SDR consumer. Isolates ka9q-radio's build deps from the host system.

https://claude.ai/code/session_01FrYBtpgjvkShrHpuqVFNC2