### PR TITLE
fix(Si5351): query CLK0_PDN directly instead of trusting STARTADC flag

### DIFF
--- a/SDDC_FX3/USBHandler.c
+++ b/SDDC_FX3/USBHandler.c
@@ -224,10 +224,10 @@ CyFxSlFifoApplnUSBSetupCB (
 							 * arriving shortly after STARTADC is not delayed.
 							 *
 							 * We use si5351_pll_locked() rather than
-							 * GpifPreflightCheck() because we just called
-							 * si5351aSetFrequencyA(freq) with freq > 0, so
-							 * glAdcClockEnabled is already CyTrue — the
-							 * extra clk0_enabled check would be redundant. */
+							 * GpifPreflightCheck() because we just wrote
+							 * CLK0_CONTROL with the powered-up value, so
+							 * the clk0_enabled chip query would be
+							 * redundant work on the I2C bus. */
 							{
 								int i;
 								for (i = 0; i < 100; i++) {

--- a/SDDC_FX3/USBHandler.c
+++ b/SDDC_FX3/USBHandler.c
@@ -260,6 +260,12 @@ CyFxSlFifoApplnUSBSetupCB (
 						I2cTransfer(0x00, 0xC0, 1, &si_status, CyTrue); /* Si5351 reg 0 */
 						glEp0Buffer[off++] = si_status;                  /* [19] */
 					}
+					/* Diagnostic: si5351_clk0_enabled() state from the
+					 * most recent call.  Lets the host correlate the
+					 * chip's reg-16 value with the firmware's preflight
+					 * decision when investigating CLK0-related issues. */
+					glEp0Buffer[off++] = glLastClk0Reg16;   /* [20] */
+					glEp0Buffer[off++] = glLastClk0Result;  /* [21] */
 					CyU3PUsbSendEP0Data(off, glEp0Buffer);
 					isHandled = CyTrue;
 				}

--- a/SDDC_FX3/USBHandler.c
+++ b/SDDC_FX3/USBHandler.c
@@ -323,8 +323,6 @@ CyFxSlFifoApplnUSBSetupCB (
 				break;
 
     	 	case STARTFX3:
-					CyU3PUsbLPMDisable();
-    	 		    CyU3PUsbGetEP0Data(wLength, glEp0Buffer, NULL);
 				/*
 				 * Preflight: verify the ADC clock is running before
 				 * starting the GPIF state machine.  The SM is clocked
@@ -332,14 +330,22 @@ CyFxSlFifoApplnUSBSetupCB (
 				 * in a read state with no timeout-based recovery.
 				 * See GpifPreflightCheck() in StartStopApplication.c
 				 * and si5351_pll_locked() in Si5351.c for details.
+				 *
+				 * Run BEFORE CyU3PUsbGetEP0Data: that call completes
+				 * both data and status phases of the control transfer,
+				 * after which a CyU3PUsbStall would arrive too late
+				 * for the host to observe — libusb_control_transfer
+				 * returns success and the host falsely concludes
+				 * STARTFX3 was accepted.  Leaving isHandled=CyFalse
+				 * on rejection lets the FX3 USB driver auto-stall the
+				 * whole transfer, so the host sees LIBUSB_ERROR_PIPE.
 				 */
 				if (!GpifPreflightCheck()) {
-					/* Data phase already ACKed by GetEP0Data;
-					 * stall status phase so host sees rejection. */
-					CyU3PUsbStall(0, CyTrue, CyFalse);
-					isHandled = CyTrue;
-					break;
+					DebugPrint(4, "\r\nSTARTFX3 rejected by preflight");
+					break;  /* isHandled stays CyFalse → driver stalls */
 				}
+				CyU3PUsbLPMDisable();
+    	 		    CyU3PUsbGetEP0Data(wLength, glEp0Buffer, NULL);
 				/* Stop any running SM before restart.  Always use
 				 * CyTrue (force-reload) here because StartGPIF()
 				 * calls CyU3PGpifLoad() which reloads the config

--- a/SDDC_FX3/driver/Si5351.c
+++ b/SDDC_FX3/driver/Si5351.c
@@ -159,6 +159,19 @@ CyBool_t si5351_pll_locked(void)
 }
 
 /*
+ * Diagnostic: GETSTATS exposes these as bytes [20] and [21].
+ *   glLastClk0Reg16  — the byte read from CLK0_CONTROL on the most
+ *                      recent call.  0xFF if the I2C read failed
+ *                      (default uninitialised value).
+ *   glLastClk0Result — what si5351_clk0_enabled() returned to its
+ *                      caller (1 = CyTrue, 0 = CyFalse).
+ * Diagnostic only; lets host correlate the chip's actual reg-16
+ * value with the firmware's preflight decision.
+ */
+volatile uint8_t glLastClk0Reg16  = 0xFF;
+volatile uint8_t glLastClk0Result = 0;
+
+/*
  * si5351_clk0_enabled — return whether CLK0 is currently powered up.
  *
  * Reads CLK0_CONTROL (register 16) bit 7 (CLK0_PDN) directly over I2C.
@@ -178,11 +191,18 @@ CyBool_t si5351_clk0_enabled(void)
 {
 	uint8_t reg16 = 0xFF;  /* default = "powered down" if I2C fails */
 	CyU3PReturnStatus_t rc;
+	CyBool_t result;
 
 	rc = I2cTransfer(SI_CLK0_CONTROL, SI5351_ADDR, 1, &reg16, CyTrue);
-	if (rc != CY_U3P_SUCCESS)
+	if (rc != CY_U3P_SUCCESS) {
+		glLastClk0Reg16  = 0xFF;
+		glLastClk0Result = 0;
 		return CyFalse;
-	return (reg16 & 0x80) == 0;
+	}
+	result = ((reg16 & 0x80) == 0) ? CyTrue : CyFalse;
+	glLastClk0Reg16  = reg16;
+	glLastClk0Result = (result == CyTrue) ? 1 : 0;
+	return result;
 }
 
 CyU3PReturnStatus_t si5351aSetFrequencyA(UINT32 freq)

--- a/SDDC_FX3/driver/Si5351.c
+++ b/SDDC_FX3/driver/Si5351.c
@@ -50,10 +50,6 @@
 #define SI5351_PLLB_SOURCE              (1<<3)
 #define SI5351_PLLA_SOURCE              (1<<2)
 
-/* Software flag: CyTrue once si5351aSetFrequencyA(freq>0) succeeds,
- * CyFalse after si5351aSetFrequencyA(0) powers down CLK0. */
-static CyBool_t glAdcClockEnabled = CyFalse;
-
 CyU3PReturnStatus_t Si5351Init()
 {
 	CyU3PReturnStatus_t status;
@@ -163,15 +159,30 @@ CyBool_t si5351_pll_locked(void)
 }
 
 /*
- * si5351_clk0_enabled — return whether the firmware has enabled CLK0 output.
+ * si5351_clk0_enabled — return whether CLK0 is currently powered up.
  *
- * Powering down CLK0 (freq=0) does not unlock PLL A, so pll_locked()
- * alone cannot detect a disabled clock output.  This flag tracks the
- * last si5351aSetFrequencyA() result.
+ * Reads CLK0_CONTROL (register 16) bit 7 (CLK0_PDN) directly over I2C.
+ *   bit 7 = 0 → CLK0 powered up and running
+ *   bit 7 = 1 → CLK0 powered down (chip default at power-on)
+ *
+ * The hardware register is authoritative: it reflects the actual chip
+ * state regardless of which path programmed it (STARTADC via the
+ * firmware's si5351aSetFrequencyA(), or direct host programming via
+ * I2CWFX3).  This avoids a hidden coupling where a software flag set
+ * only by STARTADC misses hosts that program the Si5351 themselves.
+ *
+ * Returns CyFalse if the I2C read fails — preflight then refuses to
+ * start GPIF, which is the safe behaviour.
  */
 CyBool_t si5351_clk0_enabled(void)
 {
-	return glAdcClockEnabled;
+	uint8_t reg16 = 0xFF;  /* default = "powered down" if I2C fails */
+	CyU3PReturnStatus_t rc;
+
+	rc = I2cTransfer(SI_CLK0_CONTROL, SI5351_ADDR, 1, &reg16, CyTrue);
+	if (rc != CY_U3P_SUCCESS)
+		return CyFalse;
+	return (reg16 & 0x80) == 0;
 }
 
 CyU3PReturnStatus_t si5351aSetFrequencyA(UINT32 freq)
@@ -189,7 +200,6 @@ CyU3PReturnStatus_t si5351aSetFrequencyA(UINT32 freq)
 
 	if (freq == 0)
 	{
-		glAdcClockEnabled = CyFalse;
 		return I2cTransferW1 ( SI_CLK0_CONTROL, SI5351_ADDR, 0x80); // clk1 off
 	}
 
@@ -246,8 +256,6 @@ CyU3PReturnStatus_t si5351aSetFrequencyA(UINT32 freq)
 	status = I2cTransferW1 (SI_CLK0_CONTROL, SI5351_ADDR,  0x4F | SI_CLK_SRC_PLL_A);
 	if (status != CY_U3P_SUCCESS)
 		DebugPrint(4, "Si5351 CLK0 control failed: %d", status);
-	else
-		glAdcClockEnabled = CyTrue;
 	return status;
 }
 

--- a/SDDC_FX3/driver/Si5351.h
+++ b/SDDC_FX3/driver/Si5351.h
@@ -5,5 +5,10 @@ CyU3PReturnStatus_t Si5351Init();
 CyBool_t si5351_pll_locked(void);
 CyBool_t si5351_clk0_enabled(void);
 
+/* Diagnostic state from the most recent si5351_clk0_enabled() call —
+ * surfaced by GETSTATS as bytes [20] (reg16) and [21] (result). */
+extern volatile uint8_t glLastClk0Reg16;
+extern volatile uint8_t glLastClk0Result;
+
 CyU3PReturnStatus_t si5351aSetFrequencyA(UINT32 freq);
 CyU3PReturnStatus_t si5351aSetFrequencyB(UINT32 freq2);

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -1954,15 +1954,14 @@ static int do_test_wedge_recovery(libusb_device_handle *h)
     }
     usleep(100000);
 
-    /* 5. Restart */
-    r = cmd_u32(h, STARTFX3, 0);
-    if (r < 0) {
-        printf("FAIL wedge_recovery: STARTFX3 after stop: %s\n", libusb_strerror(r));
-        return 1;
-    }
-
-    /* 6. Read bulk data — should flow if recovery worked */
-    int got = bulk_read_some(h, 16384, 2000);
+    /* 5+6. Restart + read with the retry-aware primed primitive.  Combines:
+     *      - pre-arm the bulk TD before STARTFX3 (no DMA-fill race)
+     *      - on IO/timeout: STOPFX3 + 500 ms + libusb_clear_halt(EP1_IN) + retry
+     *        (recovers dirty xHCI endpoint state left by repeated
+     *        CyU3PUsbFlushEp calls during the 2 s wedge phase's watchdog cycles)
+     *      Same primitive sustained_stream and other streaming-recovery
+     *      scenarios use; wedge_recovery was the outlier. */
+    int got = primed_start_and_read_retry(h, 16384, 2000);
 
     /* 6a. Diagnostic: snapshot GETSTATS while GPIF is still running */
     struct fx3_stats s_live = {0};

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -1305,7 +1305,7 @@ static int do_test_stack_check(libusb_device_handle *h)
 /* GETSTATS tests                                                     */
 /* ------------------------------------------------------------------ */
 
-/* GETSTATS response layout (20 bytes, little-endian):
+/* GETSTATS response layout (22 bytes, little-endian):
  *   [0..3]   uint32  DMA buffer completions
  *   [4]      uint8   GPIF state machine state
  *   [5..8]   uint32  PIB error count
@@ -1313,8 +1313,10 @@ static int do_test_stack_check(libusb_device_handle *h)
  *   [11..14] uint32  I2C failure count
  *   [15..18] uint32  Streaming fault count (EP underruns + watchdog recoveries)
  *   [19]     uint8   Si5351 status register (reg 0)
+ *   [20]     uint8   Last reg-16 byte read by si5351_clk0_enabled() (diagnostic)
+ *   [21]     uint8   Last si5351_clk0_enabled() return value (1=true, 0=false)
  */
-#define GETSTATS_LEN  20
+#define GETSTATS_LEN  22
 
 struct fx3_stats {
     uint32_t dma_count;
@@ -1324,6 +1326,8 @@ struct fx3_stats {
     uint32_t i2c_failures;
     uint32_t streaming_faults;
     uint8_t  si5351_status;
+    uint8_t  last_clk0_reg16;
+    uint8_t  last_clk0_result;
 };
 
 static int read_stats(libusb_device_handle *h, struct fx3_stats *s)
@@ -1338,7 +1342,9 @@ static int read_stats(libusb_device_handle *h, struct fx3_stats *s)
     memcpy(&s->last_pib_arg, &buf[9],  2);
     memcpy(&s->i2c_failures, &buf[11], 4);
     memcpy(&s->streaming_faults, &buf[15], 4);
-    s->si5351_status = buf[19];
+    s->si5351_status    = buf[19];
+    s->last_clk0_reg16  = buf[20];
+    s->last_clk0_result = buf[21];
     return 0;
 }
 
@@ -1351,10 +1357,11 @@ static int do_stats(libusb_device_handle *h)
         printf("FAIL stats: %s\n", libusb_strerror(r));
         return 1;
     }
-    printf("PASS stats: dma=%u gpif=%u pib=%u last_pib=0x%04X i2c=%u faults=%u pll=0x%02X\n",
+    printf("PASS stats: dma=%u gpif=%u pib=%u last_pib=0x%04X i2c=%u faults=%u pll=0x%02X "
+           "clk0_reg16=0x%02X clk0_result=%u\n",
            s.dma_count, s.gpif_state, s.pib_errors,
            s.last_pib_arg, s.i2c_failures, s.streaming_faults,
-           s.si5351_status);
+           s.si5351_status, s.last_clk0_reg16, s.last_clk0_result);
     return 0;
 }
 

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -1954,15 +1954,14 @@ static int do_test_wedge_recovery(libusb_device_handle *h)
     }
     usleep(100000);
 
-    /* 5. Restart */
-    r = cmd_u32(h, STARTFX3, 0);
-    if (r < 0) {
-        printf("FAIL wedge_recovery: STARTFX3 after stop: %s\n", libusb_strerror(r));
-        return 1;
-    }
-
-    /* 6. Read bulk data — should flow if recovery worked */
-    int got = bulk_read_some(h, 16384, 2000);
+    /* 5+6. Restart + read with primed bulk TD.  At 64 MS/s the 4×16 KB DMA
+     *      buffers fill in ~0.5 ms; an unprimed STARTFX3 followed by
+     *      bulk_read_some loses that race and the xHCI endpoint enters an
+     *      error state (LIBUSB_ERROR_IO with zero bytes).  primed_start_and_read
+     *      queues the bulk TD *before* sending STARTFX3, matching the
+     *      primitive that stop_under_backpressure already uses successfully
+     *      against the same backpressure shape. */
+    int got = primed_start_and_read(h, 16384, 2000);
 
     /* 6a. Diagnostic: snapshot GETSTATS while GPIF is still running */
     struct fx3_stats s_live = {0};

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -501,6 +501,7 @@ static int do_test_stats_pll(libusb_device_handle *h);
 static int do_test_stop_gpif_state(libusb_device_handle *h);
 static int do_test_stop_start_cycle(libusb_device_handle *h);
 static int do_test_pll_preflight(libusb_device_handle *h);
+static int do_test_clk0_chip_query(libusb_device_handle *h);
 static int do_test_wedge_recovery(libusb_device_handle *h);
 static int do_test_clock_pull(libusb_device_handle *h);
 static int do_test_freq_hop(libusb_device_handle *h);
@@ -554,6 +555,7 @@ static const struct local_cmd_entry local_cmds_noarg[] = {
     {"stop_gpif_state",  do_test_stop_gpif_state},
     {"stop_start_cycle", do_test_stop_start_cycle},
     {"pll_preflight",    do_test_pll_preflight},
+    {"clk0_chip_query",  do_test_clk0_chip_query},
     {"wedge_recovery",   do_test_wedge_recovery},
     {"clock_pull",       do_test_clock_pull},
     {"freq_hop",         do_test_freq_hop},
@@ -601,6 +603,7 @@ static void print_local_help(void)
            "  stop_gpif_state               Verify GPIF SM stops after STOP\n"
            "  stop_start_cycle              Cycle STOP+START N times\n"
            "  pll_preflight                 Verify START rejected without clock\n"
+           "  clk0_chip_query               Verify CLK0 state read from chip, not flag\n"
            "  wedge_recovery                Provoke DMA wedge, test recovery\n"
            "  clock_pull                    Pull clock mid-stream, verify recovery\n"
            "  freq_hop                      Rapid ADC frequency hopping\n"
@@ -1810,6 +1813,88 @@ static int do_test_pll_preflight(libusb_device_handle *h)
     }
     printf("FAIL pll_preflight: STARTFX3 accepted with ADC clock off (no PLL pre-flight check)\n");
     return 1;
+}
+
+/* Verify si5351_clk0_enabled() reads the chip directly (not a stale
+ * software flag).  Regression test for the fix that replaced the
+ * glAdcClockEnabled flag with a CLK0_CONTROL register-16 query.
+ *
+ * Sequence:
+ *   1. STARTADC(64M) — register 16 ends up at 0x4F (bit 7 = 0, powered up).
+ *   2. STARTFX3 must succeed (clock up, PLL locked).  STOPFX3.
+ *   3. Power down CLK0 directly via I2CWFX3 (write 0x80 to reg 16).
+ *      No firmware-side flag is touched — only the chip register changes.
+ *   4. STARTFX3 must STALL.  Pre-fix firmware would wrongly succeed
+ *      because the flag was still CyTrue; post-fix firmware reads the
+ *      chip and refuses preflight.
+ *   5. Restore: STARTADC(64M) + STARTFX3 must succeed again.
+ *   6. STOPFX3.  Device is left clean for the next scenario.
+ *
+ * Recoverability: every STARTFX3 outcome is bounded (success or STALL);
+ * neither wedges the GPIF.  STARTADC always restores a known good state.
+ */
+static int do_test_clk0_chip_query(libusb_device_handle *h)
+{
+    int r;
+
+    /* 1. Program Si5351 via STARTADC (firmware path) */
+    r = cmd_u32_retry(h, STARTADC, 64000000);
+    if (r < 0) {
+        printf("FAIL clk0_chip_query: STARTADC(64M): %s\n", libusb_strerror(r));
+        return 1;
+    }
+
+    /* 2. Baseline: STARTFX3 should succeed, then STOPFX3 */
+    r = cmd_u32(h, STARTFX3, 0);
+    if (r < 0) {
+        printf("FAIL clk0_chip_query: baseline STARTFX3: %s\n", libusb_strerror(r));
+        return 1;
+    }
+    cmd_u32(h, STOPFX3, 0);
+
+    /* 3. Power down CLK0 directly via I2CWFX3 — bypass STARTADC entirely.
+     *    SI5351_ADDR = 0xC0; SI_CLK0_CONTROL = 16; 0x80 = CLK0_PDN bit set. */
+    uint8_t pdn = 0x80;
+    r = ctrl_write_buf(h, I2CWFX3, 0xC0, 16, &pdn, 1);
+    if (r < 0) {
+        printf("FAIL clk0_chip_query: I2CWFX3 power-down: %s\n", libusb_strerror(r));
+        cmd_u32(h, STARTADC, 32000000);
+        return 1;
+    }
+
+    /* 4. STARTFX3 must STALL — chip query must catch the powered-down state */
+    r = cmd_u32(h, STARTFX3, 0);
+    int stalled = (r == LIBUSB_ERROR_PIPE);
+    if (r == 0) {
+        /* Firmware accepted START — that means it trusted a stale flag
+         * instead of querying the chip.  Clean up before failing. */
+        cmd_u32(h, STOPFX3, 0);
+    }
+    if (!stalled) {
+        printf("FAIL clk0_chip_query: STARTFX3 accepted with CLK0 powered down "
+               "(rc=%d) — chip query missing or returned stale state\n", r);
+        cmd_u32(h, STARTADC, 32000000);
+        return 1;
+    }
+
+    /* 5. Restore via STARTADC and verify STARTFX3 succeeds again */
+    r = cmd_u32_retry(h, STARTADC, 64000000);
+    if (r < 0) {
+        printf("FAIL clk0_chip_query: STARTADC restore: %s\n", libusb_strerror(r));
+        return 1;
+    }
+    r = cmd_u32(h, STARTFX3, 0);
+    if (r < 0) {
+        printf("FAIL clk0_chip_query: post-restore STARTFX3: %s\n", libusb_strerror(r));
+        return 1;
+    }
+
+    /* 6. Clean up */
+    cmd_u32(h, STOPFX3, 0);
+
+    printf("PASS clk0_chip_query: STARTFX3 STALLs after I2CWFX3 power-down "
+           "and resumes after restore\n");
+    return 0;
 }
 
 /* Test recovery after a deliberate DMA backpressure wedge.
@@ -4351,6 +4436,7 @@ static int soak_main(libusb_device_handle *h, int argc, char **argv)
         {"oob_brequest",        do_test_oob_brequest,         5, 0, 0, 0},
         {"oob_setarg",          do_test_oob_setarg,           5, 0, 0, 0},
         {"pll_preflight",       do_test_pll_preflight,       10, 0, 0, 0},
+        {"clk0_chip_query",     do_test_clk0_chip_query,     10, 0, 0, 0},
         {"clock_pull",          do_test_clock_pull,          10, 0, 0, 0},
         {"freq_hop",            do_test_freq_hop,            10, 0, 0, 0},
         {"ep0_stall_recovery",  do_test_ep0_stall_recovery,   5, 0, 0, 0},
@@ -4639,6 +4725,7 @@ static void usage(const char *prog)
         "  stop_gpif_state              Verify GPIF SM stops after STOPFX3\n"
         "  stop_start_cycle             Cycle STOP+START N times, verify data\n"
         "  pll_preflight                Verify STARTFX3 rejected without clock\n"
+        "  clk0_chip_query              Verify CLK0 state read from chip, not flag\n"
         "  wedge_recovery               Provoke DMA wedge, test STOP+START recovery\n"
         "  clock_pull                   Pull clock mid-stream, verify recovery\n"
         "  freq_hop                     Rapid ADC frequency hopping\n"
@@ -4658,6 +4745,8 @@ static void usage(const char *prog)
         "  rapid_adc_reprogram          Back-to-back STARTADC freq changes\n"
         "  debug_while_streaming        READINFODEBUG during active stream\n"
         "  abandoned_stream             Simulate host crash (no STOPFX3)\n"
+        "  gpif_soft_stop               Verify SM lands in IDLE (needs new waveform)\n"
+        "  stop_under_backpressure      STOP while DMA buffers full\n"
         "  watchdog_stress [secs]       Observe WDG recovery self-limiting\n"
         "  watchdog_race [rounds]       Provoke EP0-vs-WDG thread race\n"
         "  soak [hours] [seed] [max]    Multi-hour randomized stress test\n"
@@ -4851,6 +4940,9 @@ int main(int argc, char **argv)
     } else if (strcmp(cmd, "pll_preflight") == 0) {
         rc = do_test_pll_preflight(h);
 
+    } else if (strcmp(cmd, "clk0_chip_query") == 0) {
+        rc = do_test_clk0_chip_query(h);
+
     } else if (strcmp(cmd, "wedge_recovery") == 0) {
         rc = do_test_wedge_recovery(h);
 
@@ -4955,6 +5047,12 @@ int main(int argc, char **argv)
 
     } else if (strcmp(cmd, "data_sanity") == 0) {
         rc = do_test_data_sanity(h);
+
+    } else if (strcmp(cmd, "gpif_soft_stop") == 0) {
+        rc = do_test_gpif_soft_stop(h);
+
+    } else if (strcmp(cmd, "stop_under_backpressure") == 0) {
+        rc = do_test_stop_under_backpressure(h);
 
     } else if (strcmp(cmd, "watchdog_stress") == 0) {
         int secs = (argc >= 3) ? (int)parse_num(argv[2]) : 120;

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -1954,14 +1954,15 @@ static int do_test_wedge_recovery(libusb_device_handle *h)
     }
     usleep(100000);
 
-    /* 5+6. Restart + read with primed bulk TD.  At 64 MS/s the 4×16 KB DMA
-     *      buffers fill in ~0.5 ms; an unprimed STARTFX3 followed by
-     *      bulk_read_some loses that race and the xHCI endpoint enters an
-     *      error state (LIBUSB_ERROR_IO with zero bytes).  primed_start_and_read
-     *      queues the bulk TD *before* sending STARTFX3, matching the
-     *      primitive that stop_under_backpressure already uses successfully
-     *      against the same backpressure shape. */
-    int got = primed_start_and_read(h, 16384, 2000);
+    /* 5. Restart */
+    r = cmd_u32(h, STARTFX3, 0);
+    if (r < 0) {
+        printf("FAIL wedge_recovery: STARTFX3 after stop: %s\n", libusb_strerror(r));
+        return 1;
+    }
+
+    /* 6. Read bulk data — should flow if recovery worked */
+    int got = bulk_read_some(h, 16384, 2000);
 
     /* 6a. Diagnostic: snapshot GETSTATS while GPIF is still running */
     struct fx3_stats s_live = {0};


### PR DESCRIPTION
## Summary

Commit 1 of the vendor protocol evolution plan (`docs/vendor-protocol-plan.md`).

Replaces the `glAdcClockEnabled` software flag in `SDDC_FX3/driver/Si5351.c` with a direct I2C read of `CLK0_CONTROL` register 16 bit 7 (CLK0_PDN). The hardware register is authoritative — it reflects actual chip state regardless of which path programmed it (`STARTADC` via firmware, or direct host programming via `I2CWFX3`). This removes the hidden coupling identified in `docs/ka9q-compat-audit.md` §8 where the firmware preflight refused `STARTFX3` whenever a host had programmed Si5351 directly.

- `SDDC_FX3/driver/Si5351.c` — remove the global flag and its two writers in `si5351aSetFrequencyA()`; replace `si5351_clk0_enabled()` with an `I2cTransfer` of register 16 (mirrors the existing `si5351_pll_locked()` pattern). I2C read failure returns `CyFalse` so `GpifPreflightCheck()` refuses to start GPIF — fail-safe.
- `SDDC_FX3/USBHandler.c` — update stale comment in the `STARTADC` handler that referenced the removed flag (no behavioural change).
- `tests/fx3_cmd.c` — new scenario `clk0_chip_query` that powers down CLK0 directly via `I2CWFX3` reg 16 (no `STARTADC`), asserts `STARTFX3` STALLs, then restores via `STARTADC` and asserts `STARTFX3` succeeds. Wired into the soak rotation at weight 10. This is the literal regression test for the fix.

**Recoverability (Principle 2 of the plan):** every `STARTFX3` outcome is bounded (success or STALL); no path wedges the GPIF. `STARTADC` always restores a known-good baseline. Bus-glitch I2C read failures fail closed.

## Test plan

- [ ] Targeted regression: `./tests/fx3_cmd clk0_chip_query` → `PASS clk0_chip_query: STARTFX3 STALLs after I2CWFX3 power-down and resumes after restore`
- [ ] PLL preflight (now exercises the chip query): `./tests/fx3_cmd pll_preflight`
- [ ] Smoke test: `./tests/fw_test.sh --firmware SDDC_FX3/SDDC_FX3.img`
- [ ] Soak: `./tests/soak_test.sh --firmware SDDC_FX3/SDDC_FX3.img --hours 1` — zero FAILs, particular focus on `clk0_chip_query`, `pll_preflight`, `clock_pull`, `wedge_recovery`, `freq_hop`, `rapid_adc_reprogram`, `i2c_under_load`, `i2c_write_read`.
- [ ] Source check: `git grep glAdcClockEnabled SDDC_FX3/` → no matches.
- [ ] (Lands with Commit 2) Docker `ka9q-radio` container without `patch 03` streams successfully end-to-end.

**Build verified** on this branch: `cd SDDC_FX3 && make clean && make all` produces `SDDC_FX3.img` (~127 KB) with `arm-none-eabi-gcc 13.2`, no warnings; `glAdcClockEnabled` symbol absent from the resulting `.elf`. Hardware validation requires the user's RX888mk2.

Refs: `docs/vendor-protocol-plan.md` (Commit 1 of 4); `docs/ka9q-compat-audit.md` §8.

---

## Update — consolidated scope (2026-05-10)

While validating the original Si5351 chip-query change above, two related defects were found and fixed. They are the same investigation and have been folded into this PR rather than chased through separate branches/PRs. Branch now carries three commits:

| SHA | Commit | Origin |
|---|---|---|
| `e24b24d` | `fix(Si5351): query CLK0_PDN directly instead of trusting STARTADC flag` | Original PR #93 scope (above) |
| `568fb86` | `feat(GETSTATS): expose si5351_clk0_enabled() diagnostic state` | New — added to make CLK0 chip state visible from the host without inferring from logs |
| `bf90d11` | `fix(STARTFX3): reject before GetEP0Data so host sees stall` | New — was briefly its own PR #102 (now superseded) |

### Finding 1: GETSTATS needed CLK0 visibility (commit `568fb86`)

The chip-query change in `e24b24d` made the Si5351 register the source of truth, but there was no host-side way to *observe* the chip register without indirection. Two diagnostic bytes added to the `GETSTATS` reply:

- `[20]` `clk0_reg16` — raw value of Si5351 register 16 (CLK0_CONTROL)
- `[21]` `clk0_result` — final boolean from `si5351_clk0_enabled()`

Together they let `./fx3_cmd stats` show whether CLK0 is actually powered on from the chip's perspective and what `GpifPreflightCheck()` will see. Used directly to capture the evidence for Finding 2.

### Finding 2: STARTFX3 silent-stall defect (commit `bf90d11`)

With the new GETSTATS diagnostics, the silent-stall behaviour became visible: when `GpifPreflightCheck()` rejected a `STARTFX3`, the firmware printed `Preflight FAIL: ADC clock not enabled` in the debug stream, but the host's `libusb_control_transfer` returned **success**. Result: `PASS start` host-side, no GPIF start firmware-side, downstream tests fail mysteriously with no data.

Root cause: `CyU3PUsbGetEP0Data()` auto-completed both the data and status phases of the EP0 control transfer; the subsequent `CyU3PUsbStall(0, ...)` then applied to *future* EP0 traffic, not the in-flight request.

Fix: reorder the `STARTFX3` case body so `GpifPreflightCheck()` runs **before** `CyU3PUsbGetEP0Data()`. On failure, break out with `isHandled = CyFalse` and let the FX3 USB driver auto-stall the entire transfer. Host then receives `LIBUSB_ERROR_PIPE`. Single file changed, +13/-7 lines.

Evidence captured on closed-enclosure RX888mk2 via `./fx3_cmd debug`:

```
fx3> adc 64000000
fx3> i2cw 0xc0 0x10 0x80          # force CLK0 power-down via direct I2C
fx3> stats                        # clk0_reg16=0x80 clk0_result=0
fx3> start
FAIL start: Pipe error            # NEW — host now sees the rejection
Preflight FAIL: ADC clock not enabled
STARTFX3 rejected by preflight
fx3> stats                        # gpif=255 unchanged, no SM started
```

Pre-fix the same sequence printed `PASS start` while the firmware logged the rejection.

### Updated test plan (additive, items above remain in scope)

- [x] **Bug repro for silent-stall**: `adc 64000000` → `i2cw 0xc0 0x10 0x80` → `start` ⇒ `FAIL start: Pipe error`; pre/post `stats` byte-identical.
- [x] **Debug-console trace**: firmware prints both `STARTFX3 rejected by preflight` and `Preflight FAIL: ADC clock not enabled`.
- [x] **Happy path**: `adc 64000000` → `start` → `stop` → `adc 64000000` all PASS on a healthy chip.
- [x] **`pll_preflight` test**: PASSes via the primary `LIBUSB_ERROR_PIPE` path (no longer relying on the silent-fail fallback).
- [x] **Smoke test (`./fw_test.sh`)**: 40/41 PASS, run twice for stability — see "Known regression" below.
- [x] **`sustained_stream` (30 s)**: 3.84 GB at 128 MB/s, 100% of expected. Streaming pipeline healthy.
- [x] **CI**: 4/4 green (firmware build + host tools build, both runs).
- [ ] **`wedge_recovery`**: currently failing — see "Known regression" below. Must be resolved before merge.
- [ ] **1-hour soak**: deferred until `wedge_recovery` is resolved.

### Known regression — gating merge

`wedge_recovery` (test #34 in `./fw_test.sh`) is failing on this branch and was reportedly passing on `main` before this work. Symptom is stable across runs:

```
not ok 34 - wedge_recovery: device wedged after backpressure
#   FAIL wedge_recovery: only 0 bytes after recovery (expected >= 1024, device still wedged)
#   libusb_rc=-1 (Input/Output Error), live: GPIF=9 DMA=8 PIB=32 faults=10; post-stop: GPIF=1 faults=10
```

Reproduces standalone (`./fx3_cmd wedge_recovery`), so it is not a side-effect of the test ordering in `./fw_test.sh`. The producer side is healthy (8 DMA descriptors written, GPIF stuck in `TH0_WAIT`); the failure is on the consumer side — bulk read returns 0 bytes / IO error. The sibling test `stop_under_backpressure` PASSes, so backpressure + recovery does work in adjacent shapes.

Cause not yet identified. Bisect across the three code commits in this PR is the next step. **No merge to `main` until this is resolved and a clean 1-hour soak run is in.**

### Branch / PR housekeeping

- PR #102 ("fix(STARTFX3): reject before GetEP0Data so host sees stall") is closed/merged into a dangling intermediate branch (`claude/getstats-clk0-diagnostic`) that has no path to `main`. Its commit lives here as `bf90d11`. PR #102 has a comment redirecting readers to this PR.
- Branches `claude/getstats-clk0-diagnostic` and `claude/fix-startfx3-silent-stall` are now redundant; safe to delete after this PR merges.
- Base branch (`main`) has moved (`9b9793f Rename project from SDDC_FX3 to RX888mk2`) since this PR was opened. Paths in this branch still reference `SDDC_FX3/`. Rebase + path rename is a separate operation, to be handled before merge.