### PR TITLE
chore(github): add multi-template PR descriptions for hardware/CI checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/ci.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ci.md
@@ -1,0 +1,26 @@
+<!--
+Use this template for PRs that touch .github/ (workflows, PR
+templates, issue templates, repo automation).
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what was added, removed, or changed. -->
+
+## Author self-check
+
+- [ ] YAML lint passes: `python3 -c "import yaml; yaml.safe_load(open('<workflow>'))"`.
+- [ ] If a new workflow was added, it has run on this PR and the result is visible in the "Checks" tab.
+- [ ] If an existing workflow was modified, its run on this PR is green (and matches the intended new behaviour, not just "still passes").
+- [ ] No secrets committed (`mcp__github__run_secret_scanning` clean if anything sensitive is referenced).
+
+## Reviewer checks
+
+- [ ] The workflow on this PR ran and passed (look at "Checks" tab — required).
+- [ ] If a job was renamed or restructured, branch protection rules (if any) still match the new job names.
+- [ ] If a template was added or modified, render it on a test PR via `?template=<name>.md` to confirm.
+
+## Notes for reviewer
+
+<!-- Anything that wouldn't be obvious from the workflow diff:
+matrix coverage trade-offs, planned future jobs, deferred concerns. -->

--- a/.github/PULL_REQUEST_TEMPLATE/docker.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docker.md
@@ -1,0 +1,26 @@
+<!--
+Use this template for PRs that touch docker/ (Dockerfiles, helper
+scripts, ka9q-radio patches, container READMEs).
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changed and why. -->
+
+## Author self-check
+
+- [ ] CI is green.
+- [ ] Image builds cleanly from scratch: `docker build --no-cache -t ka9q-radio docker/ka9q-radio/` (or the equivalent for the touched container).
+- [ ] If a `patches/` file was added or removed, `docker/ka9q-radio/patches/README.md` is updated and `docker/ka9q-radio/README.md` "Known compatibility notes" is consistent.
+- [ ] No firmware-side fix exists that would supersede a new container patch — if it does, fix the firmware instead.
+
+## Reviewer hardware checks (RX888mk2 required)
+
+- [ ] Image builds locally with `docker build --no-cache`.
+- [ ] Helper script flow works end-to-end: `./ka9q.sh start` → `./ka9q.sh monitor` produces audible output on the configured RX888mk2.
+- [ ] No regressions in tunes/sample rates that previously worked.
+
+## Notes for reviewer
+
+<!-- Container-specific quirks, expected logs, host kernel/USB
+prerequisites, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,21 @@
+<!--
+Use this template for PRs that ONLY touch documentation: docs/,
+README.md, top-level *.md, in-source comments.  If the same PR also
+changes code or build, use one of the other templates instead.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what was clarified, added, or removed. -->
+
+## Author self-check
+
+- [ ] Per CLAUDE.md "Issue Filing Policy" / general doc-change discipline: every code or behaviour claim is grounded in actual source — no speculation.
+- [ ] Cross-references (`docs/architecture.md`, `docs/vendor-protocol-plan.md`, audit docs, etc.) still resolve.
+- [ ] Markdown renders correctly (lists, code fences, tables) — preview locally or via the GitHub Files Changed tab.
+- [ ] Deprecated commands or removed features are clearly flagged where readers would otherwise stumble on them.
+
+## Reviewer checks
+
+- [ ] Random-spot grep / `Read` of one or two cited file:line references confirms they say what the PR claims.
+- [ ] No new orphaned or contradictory cross-references introduced.

--- a/.github/PULL_REQUEST_TEMPLATE/firmware.md
+++ b/.github/PULL_REQUEST_TEMPLATE/firmware.md
@@ -1,0 +1,42 @@
+<!--
+Use this template for PRs that touch SDDC_FX3/ (firmware sources,
+driver, radio, GPIF, USB handlers, protocol.h, etc.).
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what changed and why. -->
+
+## Recoverability check (Principle 2)
+
+<!--
+Per docs/vendor-protocol-plan.md, no firmware change may leave the
+RX888 in a state requiring a power cycle to recover.  Address each:
+-->
+
+- [ ] All new code paths return to EP0 idle within a bounded time (no infinite loops, no busy-waits without timeout).
+- [ ] Malformed payloads (wrong length, out-of-range values) are rejected at the EP0 boundary without corrupting internal state.
+- [ ] `RESETFX3` and `STOPFX3` still work from any state this change can reach.
+- [ ] Soak/fuzz coverage exists (existing scenario or new one in `tests/fx3_cmd.c`); call it out below.
+
+## Author self-check
+
+- [ ] CI is green (`SDDC_FX3 firmware (arm-none-eabi)` + `Host test tools`).
+- [ ] Local build with `make -C SDDC_FX3 clean all` produces `SDDC_FX3.img` with no new warnings.
+- [ ] If the wire protocol or vendor command set changed, `docs/architecture.md` and `docs/vendor-protocol-plan.md` are updated.
+- [ ] If a host-side patch (e.g. `docker/ka9q-radio/patches/`) becomes redundant, it is removed in this PR (or noted as a follow-up commit).
+
+## Reviewer hardware checks (RX888mk2 required)
+
+<!-- These cannot run in CI.  Tick when you have run them locally. -->
+
+- [ ] Targeted regression test passes: `./tests/fx3_cmd <scenario>` (specify which: ____).
+- [ ] Soak run is clean: `./tests/soak_test.sh --firmware SDDC_FX3/SDDC_FX3.img --hours 1` — zero FAIL lines.
+- [ ] Docker ka9q-radio container streams audio against the new firmware: `cd docker/ka9q-radio && ./ka9q.sh start && ./ka9q.sh monitor`.
+- [ ] After all tests, device returns cleanly to either bootloader (`04b4:00f3`) or known-good app state (`04b4:00f1`) — no power cycle required.
+
+## Notes for reviewer
+
+<!-- Anything not obvious from the diff: which scenarios stress this
+change, which existing scenarios it relies on, known limitations,
+follow-up work. -->


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE/` with four named templates that GitHub surfaces in the PR-creation UI dropdown (or via `?template=<name>.md`):

- **`firmware.md`** — `SDDC_FX3/` changes. Includes a "Recoverability check (Principle 2)" section derived from `docs/vendor-protocol-plan.md`, plus reviewer hardware checks (targeted regression scenario, soak run, docker ka9q-radio audio, clean device-state recovery).
- **`docker.md`** — `docker/` changes. Reviewer checks for `--no-cache` image build and `ka9q.sh` streaming.
- **`docs.md`** — docs-only PRs. Author self-check enforces the `CLAUDE.md` "claims grounded in source" rule.
- **`ci.md`** — `.github/` changes. Confirms the workflow's own run on the PR is green.

No top-level `pull_request_template.md` — PR bodies stay empty unless a template is explicitly picked, avoiding a one-size-fits-all checklist on tiny PRs.

## Test plan

- [ ] After merge, "Compare & pull request" on a feature branch shows a dropdown listing all four templates.
- [ ] URL form works: `/compare/main...<branch>?template=firmware.md` pre-fills the body with the firmware checklist.
- [ ] Markdown renders cleanly — comment blocks (`<!-- ... -->`), checklists, and headers display as expected when a template is loaded.
- [ ] Existing PRs (#93) are unaffected — templates only apply at PR-creation time.

This PR itself does **not** use any of the new templates (they aren't visible until merged into `main`); the body above is hand-written.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_