### PR TITLE
ci(release): add tag-driven release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  firmware:
+    name: Build SDDC_FX3 firmware
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ARM cross-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi
+
+      - name: Build firmware
+        run: make -C SDDC_FX3 clean all
+
+      - name: Rename artifact with tag
+        run: cp SDDC_FX3/SDDC_FX3.img "SDDC_FX3-${GITHUB_REF_NAME}.img"
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: SDDC_FX3-${{ github.ref_name }}.img
+          if-no-files-found: error
+
+  host-tools:
+    name: Build host tools (Linux x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install host build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libusb-1.0-0-dev pkg-config
+
+      - name: Build test tools
+        run: make -C tests
+
+      - name: Stage host tools with tag-suffixed names
+        run: |
+          mkdir -p host-tools-out
+          cp tests/fx3_cmd "host-tools-out/fx3_cmd-${GITHUB_REF_NAME}-linux-x86_64"
+          # rx888_stream is a symlink in tests/; resolve to the real binary.
+          cp "$(readlink -f tests/rx888_stream)" \
+             "host-tools-out/rx888_stream-${GITHUB_REF_NAME}-linux-x86_64"
+
+      - name: Upload host-tools artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-tools
+          path: host-tools-out/
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    needs: [firmware, host-tools]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware
+          path: assets/
+
+      - name: Download host-tools artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: host-tools
+          path: assets/
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: assets/*
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — tag-driven release workflow that publishes firmware and host tools as GitHub release assets.

**Trigger:** push of any tag matching `v*` (e.g. `v0.1.0`, `v0.1.0-rc1`).

**Three jobs:**
- **`firmware`** — same toolchain install as `build.yml` (`gcc-arm-none-eabi` + `libnewlib-arm-none-eabi`), builds `SDDC_FX3.img`, stages as `SDDC_FX3-<tag>.img`.
- **`host-tools`** — same submodule + libusb setup as `build.yml`, builds `fx3_cmd` and `rx888_stream`, stages as `fx3_cmd-<tag>-linux-x86_64` and `rx888_stream-<tag>-linux-x86_64` (resolves the `rx888_stream` symlink first).
- **`release`** — depends on both; downloads artifacts and calls `softprops/action-gh-release@v2` with `generate_release_notes: true` (auto-summarises PRs since the previous tag) and `prerelease: contains(tag, '-')` so `v*-rc*` lands as a prerelease.

**Permissions:** `contents: write` scoped to the release job only. Uses default `GITHUB_TOKEN` — no PAT.

**Out of scope** (deferable): macOS / Windows host-tools builds, signed firmware, manual `workflow_dispatch` trigger, downstream notifications.

## Test plan

- [ ] YAML lints: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` (verified during preparation).
- [ ] After merge, dry-run with a throwaway prerelease tag:
  ```
  git tag v0.0.0-test && git push origin v0.0.0-test
  # observe Actions run; verify the prerelease and three assets
  gh release delete v0.0.0-test --yes && git push --delete origin v0.0.0-test
  ```
- [ ] First real release: `git tag v0.1.0 && git push origin v0.1.0` → release at `/releases/tag/v0.1.0` with three assets and auto-generated notes.
- [ ] `build.yml` continues to run unaffected on `push` / `pull_request`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_