### PR TITLE
docs(README): add latest-release and CI status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SDDC_FX3 Firmware
 
+[![Latest release](https://img.shields.io/github/v/release/ringof/ExtIO_sddc?include_prereleases&label=latest%20release)](https://github.com/ringof/ExtIO_sddc/releases/latest)
+[![Build](https://github.com/ringof/ExtIO_sddc/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ringof/ExtIO_sddc/actions/workflows/build.yml?query=branch%3Amain)
+
 Cypress FX3 USB controller firmware for the RX888mk2 and related
 direct-sampling SDR hardware.
 


### PR DESCRIPTION
## Summary

Adds two badges immediately under the top-level H1 in `README.md`:

- **Latest release** — shields.io badge with `include_prereleases=true` so `v0.1.0-rc0` (and future prereleases) show up; links to `/releases/latest`.
- **Build** — GitHub Actions native badge for `build.yml`, filtered to `branch=main` so feature-branch failures don't make it red; links to the filtered Actions list.

GitHub's right-hand "Releases" widget already exists once a release is published, but a badge in the README header is far more discoverable for first-time visitors looking for firmware to download.

## Author self-check (per docs.md template)

- [x] Per `CLAUDE.md` "Issue Filing Policy" / general doc-change discipline: every claim is grounded in actual source — the badge URLs reference real workflows (`build.yml`, merged in PR #94) and the GitHub releases API.
- [x] Cross-references resolve: `/actions/workflows/build.yml`, `/releases/latest`.
- [x] Markdown renders correctly — preview locally; both badge images load and links click through.
- [x] Deprecated commands or removed features are clearly flagged where readers would otherwise stumble on them — N/A for this change.

## Reviewer checks

- [ ] Random-spot grep / `Read` of one or two cited file:line references confirms they say what the PR claims — N/A; no code claims here.
- [ ] No new orphaned or contradictory cross-references introduced.
- [ ] Both badges render in the README header on the PR's "Files changed" preview.
- [ ] Latest-release badge currently reads "no releases" (or similar) until `v0.1.0-rc0` is pushed; will then auto-update to that tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_