### PR TITLE
ci(release): add workflow_dispatch trigger to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,28 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to (re)build and publish (e.g. v0.1.0-rc0)'
+        required: true
+        type: string
+
+# Resolve the tag from either trigger.  On push:tags, github.ref_name is
+# the tag; on workflow_dispatch, it's the branch the run was launched
+# from, so we fall back to the user-supplied input.
+env:
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
   firmware:
     name: Build SDDC_FX3 firmware
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (at tag)
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
 
       - name: Install ARM cross-compiler
         run: |
@@ -22,22 +36,23 @@ jobs:
         run: make -C SDDC_FX3 clean all
 
       - name: Rename artifact with tag
-        run: cp SDDC_FX3/SDDC_FX3.img "SDDC_FX3-${GITHUB_REF_NAME}.img"
+        run: cp SDDC_FX3/SDDC_FX3.img "SDDC_FX3-${TAG}.img"
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
           name: firmware
-          path: SDDC_FX3-${{ github.ref_name }}.img
+          path: SDDC_FX3-${{ env.TAG }}.img
           if-no-files-found: error
 
   host-tools:
     name: Build host tools (Linux x86_64)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout (with submodules)
+      - name: Checkout (at tag, with submodules)
         uses: actions/checkout@v4
         with:
+          ref: ${{ env.TAG }}
           submodules: recursive
 
       - name: Install host build dependencies
@@ -51,10 +66,10 @@ jobs:
       - name: Stage host tools with tag-suffixed names
         run: |
           mkdir -p host-tools-out
-          cp tests/fx3_cmd "host-tools-out/fx3_cmd-${GITHUB_REF_NAME}-linux-x86_64"
+          cp tests/fx3_cmd "host-tools-out/fx3_cmd-${TAG}-linux-x86_64"
           # rx888_stream is a symlink in tests/; resolve to the real binary.
           cp "$(readlink -f tests/rx888_stream)" \
-             "host-tools-out/rx888_stream-${GITHUB_REF_NAME}-linux-x86_64"
+             "host-tools-out/rx888_stream-${TAG}-linux-x86_64"
 
       - name: Upload host-tools artifact
         uses: actions/upload-artifact@v4
@@ -85,6 +100,7 @@ jobs:
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.TAG }}
           files: assets/*
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(env.TAG, '-') }}


### PR DESCRIPTION
## Summary

Lets the release workflow be re-run from the Actions UI for any existing tag — past or future — without re-tagging. Specifically fixes the case where `v0.1.0-rc0` was pushed before `release.yml` existed on `main`, so the workflow never ran for that tag and the release has no firmware/host-tools assets.

Edits `.github/workflows/release.yml` only:

- Add `workflow_dispatch:` trigger with a required `tag` string input.
- Top-level `env.TAG` resolves from `inputs.tag` (dispatch) or `github.ref_name` (push:tags).
- Both `actions/checkout@v4` steps use `ref: ${{ env.TAG }}` so manual runs build against the tag's source, not whatever `main` happens to be.
- `softprops/action-gh-release@v2` uses `tag_name: ${{ env.TAG }}` so it attaches assets to an existing release in place rather than creating a new one.

Tag-push flow is preserved bit-for-bit (`env.TAG` falls back to `github.ref_name`, checkout `ref:` equals it, asset names match what `GITHUB_REF_NAME` produced before).

## Author self-check (per ci.md template)

- [x] YAML lint passes: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → yaml OK.
- [x] No new workflow added; existing one modified. Its tag-push trigger is unaffected and was previously verified by PR #96.
- [x] Existing workflow modified — its run on this PR can't exercise the change (no tag is being pushed and `workflow_dispatch` doesn't fire on PR events). Validation is post-merge.
- [x] No secrets committed.

## Reviewer checks

- [ ] Post-merge: Actions tab → "release" workflow → "Run workflow" → Tag: `v0.1.0-rc0` → run.
- [ ] Three jobs (`firmware`, `host-tools`, `release`) all green.
- [ ] `/releases/tag/v0.1.0-rc0` now shows three attached assets:
  - `SDDC_FX3-v0.1.0-rc0.img`
  - `fx3_cmd-v0.1.0-rc0-linux-x86_64`
  - `rx888_stream-v0.1.0-rc0-linux-x86_64`
- [ ] Latest-release badge in README continues to show `v0.1.0-rc0` (state unchanged).
- [ ] Tag-push path still works — verifiable later by pushing any throwaway prerelease tag (e.g. `v0.0.0-test`) and confirming the workflow runs and publishes.

## Notes

`softprops/action-gh-release@v2` updates an existing release in place rather than recreating it. With `generate_release_notes: true`, pre-existing release body is **preserved** (the action only generates notes if the body is empty). So the auto-generated notes already on `v0.1.0-rc0` will not be overwritten — only assets get added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_