### PR TITLE
ci(release): drop tag suffix from stable-release asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,16 @@ jobs:
         with:
           ref: ${{ env.TAG }}
 
+      - name: Determine asset suffix (stable tags drop the tag suffix)
+        run: |
+          # Stable tag (e.g. v1.0.0) → empty suffix → drop-in name SDDC_FX3.img
+          # Prerelease (e.g. v1.0.0-rc1) → -<TAG> suffix → SDDC_FX3-v1.0.0-rc1.img
+          if [[ "${TAG}" == *-* ]]; then
+            echo "ASSET_SUFFIX=-${TAG}" >> "$GITHUB_ENV"
+          else
+            echo "ASSET_SUFFIX=" >> "$GITHUB_ENV"
+          fi
+
       - name: Install ARM cross-compiler
         run: |
           sudo apt-get update
@@ -35,14 +45,14 @@ jobs:
       - name: Build firmware
         run: make -C SDDC_FX3 clean all
 
-      - name: Rename artifact with tag
-        run: cp SDDC_FX3/SDDC_FX3.img "SDDC_FX3-${TAG}.img"
+      - name: Rename artifact
+        run: cp SDDC_FX3/SDDC_FX3.img "SDDC_FX3${ASSET_SUFFIX}.img"
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
           name: firmware
-          path: SDDC_FX3-${{ env.TAG }}.img
+          path: SDDC_FX3${{ env.ASSET_SUFFIX }}.img
           if-no-files-found: error
 
   host-tools:
@@ -55,6 +65,14 @@ jobs:
           ref: ${{ env.TAG }}
           submodules: recursive
 
+      - name: Determine asset suffix (stable tags drop the tag suffix)
+        run: |
+          if [[ "${TAG}" == *-* ]]; then
+            echo "ASSET_SUFFIX=-${TAG}" >> "$GITHUB_ENV"
+          else
+            echo "ASSET_SUFFIX=" >> "$GITHUB_ENV"
+          fi
+
       - name: Install host build dependencies
         run: |
           sudo apt-get update
@@ -63,13 +81,13 @@ jobs:
       - name: Build test tools
         run: make -C tests
 
-      - name: Stage host tools with tag-suffixed names
+      - name: Stage host tools
         run: |
           mkdir -p host-tools-out
-          cp tests/fx3_cmd "host-tools-out/fx3_cmd-${TAG}-linux-x86_64"
+          cp tests/fx3_cmd "host-tools-out/fx3_cmd${ASSET_SUFFIX}-linux-x86_64"
           # rx888_stream is a symlink in tests/; resolve to the real binary.
           cp "$(readlink -f tests/rx888_stream)" \
-             "host-tools-out/rx888_stream-${TAG}-linux-x86_64"
+             "host-tools-out/rx888_stream${ASSET_SUFFIX}-linux-x86_64"
 
       - name: Upload host-tools artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Stable releases now publish drop-in-named assets that match the build-output filename:

- `SDDC_FX3.img`
- `fx3_cmd-linux-x86_64`
- `rx888_stream-linux-x86_64`

Prereleases (tags with a hyphen — `v1.0.0-rc1`, `v0.1.0-rc0`) keep the existing tag-suffixed names so testers comparing multiple rcs in their downloads folder see distinct filenames.

Edits `.github/workflows/release.yml` only:

- Both build jobs (`firmware`, `host-tools`) gain a "Determine asset suffix" step that sets `ASSET_SUFFIX` in `$GITHUB_ENV`: empty for stable tags, `-${TAG}` for prereleases. The condition is the same `[[ "${TAG}" == *-* ]]` test the workflow already uses for `prerelease:`.
- Rename / staging steps interpolate `${ASSET_SUFFIX}` between the base name and the extension/suffix.
- `upload-artifact` paths use `${{ env.ASSET_SUFFIX }}` (env vars set via `$GITHUB_ENV` are visible to subsequent `${{ env.* }}` expressions in the same job).
- The release job is unchanged (`files: assets/*` glob, `prerelease: contains(env.TAG, '-')`).

## Author self-check (per ci.md template)

- [x] YAML lint passes: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → yaml OK.
- [x] No new workflow added; existing one modified. Tag-push trigger and `workflow_dispatch` are both preserved.
- [x] PR's own CI doesn't exercise this change (no tag pushed, `workflow_dispatch` doesn't fire on PR events). Validation is post-merge.
- [x] No secrets committed.

## Reviewer checks

- [ ] Post-merge: re-run release workflow for `v0.1.0-rc0` via `workflow_dispatch`. Expected assets keep tag suffix (hyphen present): `SDDC_FX3-v0.1.0-rc0.img`, `fx3_cmd-v0.1.0-rc0-linux-x86_64`, `rx888_stream-v0.1.0-rc0-linux-x86_64`.
- [ ] Throwaway stable test tag: `git tag v0.0.1 && git push origin v0.0.1` → assets named `SDDC_FX3.img`, `fx3_cmd-linux-x86_64`, `rx888_stream-linux-x86_64`. Then `gh release delete v0.0.1 --yes && git push --delete origin v0.0.1`.
- [ ] Latest-release badge in README continues to work (independent of asset naming).

## Notes

If a tag is re-run later and the existing release already has assets, `softprops/action-gh-release@v2` *adds* the new files alongside the old ones rather than replacing. For our current state (no stable release exists yet) that's not a concern. If it becomes one, the action supports asset replacement flags we can add later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_