### PR TITLE
docs(README): lead with RX888 mk2; add Compatible host applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,25 @@
 [![Latest release](https://img.shields.io/github/v/release/ringof/ExtIO_sddc?include_prereleases&label=latest%20release)](https://github.com/ringof/ExtIO_sddc/releases/latest)
 [![Build](https://github.com/ringof/ExtIO_sddc/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ringof/ExtIO_sddc/actions/workflows/build.yml?query=branch%3Amain)
 
-Cypress FX3 USB controller firmware for the RX888mk2 and related
-direct-sampling SDR hardware.
+Cypress FX3 USB controller firmware for the **RX888 mk2** (also written
+RX888mk2) direct-sampling SDR receiver. HF reception (0–32 MHz) via the
+on-board LTC2208 ADC; the R828D VHF tuner is detected but not driven by
+the firmware (see Limitations).
 
-This repository is a fork of the firmware portion of
-[ExtIO_sddc](https://github.com/ik1xpv/ExtIO_sddc), stripped down to
-support the RX888mk2 (rx888r2) hardware only.
+## Compatible host applications
+
+- **[ka9q-radio](https://github.com/ka9q/ka9q-radio)** — multichannel
+  software-defined-radio receiver with native RX888 support. Validated
+  end-to-end via the bundled Docker test container; see
+  [`docker/ka9q-radio/`](docker/ka9q-radio/) for setup.
+- **[rx888_tools](https://github.com/ringof/rx888_tools)** — streamer,
+  DSP utilities, and udev rules maintained alongside this firmware. The
+  `rx888_stream` binary from this project is the firmware uploader and
+  USB capture tool used by the test harness in [`tests/`](tests/).
+- **ExtIO-based Windows hosts** (HDSDR, SDR Console) — historically
+  supported via the upstream
+  [ExtIO_sddc](https://github.com/ik1xpv/ExtIO_sddc) project. This fork
+  is firmware-only and does not include the ExtIO DLL.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

Improves discoverability and orientation of the README:

- **Intro paragraph tweaked** to lead with both spellings of "RX888 mk2" (with and without the space — common search variants), state the firmware's role (HF 0–32 MHz via LTC2208), and flag the R828D VHF tuner as detected-only.
- **New "Compatible host applications" section** added right after the intro, listing:
  - **[ka9q-radio](https://github.com/ka9q/ka9q-radio)** — links to the bundled `docker/ka9q-radio/` test container.
  - **[rx888_tools](https://github.com/ringof/rx888_tools)** — the streamer + DSP utilities maintained alongside this firmware; `rx888_stream` is the firmware uploader / capture tool used by the `tests/` harness.
  - **ExtIO-based Windows hosts** (HDSDR, SDR Console) — historical pointer to upstream `ExtIO_sddc`; clarifies this fork is firmware-only.
- **Old standalone "fork of ExtIO_sddc" paragraph removed** — content folded into the third bullet. Acknowledgments section continues to credit upstream by name.

Net diff: +19 / −6 lines, README.md only. Badge URLs and all other sections unchanged. The latter is intentional — they redirect transparently after a future repo rename, so updating preemptively would gain nothing and risks breaking now.

## Author self-check (per docs.md template)

- [x] Per `CLAUDE.md` "Issue Filing Policy": every claim is grounded in actual source — `docker/ka9q-radio/` exists; `tests/rx888_tools` is the existing submodule; LTC2208 / RX888mk2 / R828D are documented in `docs/architecture.md` and the existing Limitations section.
- [x] Cross-references resolve: ka9q-radio upstream URL, rx888_tools URL, ExtIO_sddc URL, `docker/ka9q-radio/` relative link, `tests/` relative link.
- [x] Markdown renders correctly — preview locally, all bullets / links / bold formatting display as expected.
- [x] No deprecated commands or removed features touched.

## Reviewer checks

- [ ] Random-spot grep / `Read` of one or two cited file:line references — N/A; no new code claims.
- [ ] No new orphaned or contradictory cross-references introduced.
- [ ] Click-throughs: all four external links and two relative links resolve.
- [ ] On the rendered repo home page, the new section appears between intro and Limitations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_