### PR TITLE
docs(README): point badges at rx888-firmware (post-rename cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SDDC_FX3 Firmware
 
-[![Latest release](https://img.shields.io/github/v/release/ringof/ExtIO_sddc?include_prereleases&label=latest%20release)](https://github.com/ringof/ExtIO_sddc/releases/latest)
-[![Build](https://github.com/ringof/ExtIO_sddc/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ringof/ExtIO_sddc/actions/workflows/build.yml?query=branch%3Amain)
+[![Latest release](https://img.shields.io/github/v/release/ringof/rx888-firmware?include_prereleases&label=latest%20release)](https://github.com/ringof/rx888-firmware/releases/latest)
+[![Build](https://github.com/ringof/rx888-firmware/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ringof/rx888-firmware/actions/workflows/build.yml?query=branch%3Amain)
 
 Cypress FX3 USB controller firmware for the **RX888 mk2** (also written
 RX888mk2) direct-sampling SDR receiver. HF reception (0–32 MHz) via the


### PR DESCRIPTION
## Summary

Updates the two README badge URLs from `ringof/ExtIO_sddc` to `ringof/rx888-firmware` after the repository rename.

The repo was renamed to better reflect what it actually does. GitHub auto-redirects old URLs, so the badges still worked before this change — but updating the in-tree URLs avoids long-term dependence on those redirects.

Two-line edit, README.md only:
- Latest-release badge: shields.io endpoint and click-through target both substituted.
- Build badge: same.

Repo-wide grep finds one additional reference in `docker/ka9q-radio/patches/03-startadc-before-startfx3.patch`. That file is slated for **deletion** in Commit 2 of `docs/vendor-protocol-plan.md`, so it's intentionally left as-is — updating a file scheduled for removal would be doomed work, and the GitHub redirect handles it for its remaining lifetime.

## Author self-check (per docs.md template)

- [x] Per `CLAUDE.md` "Issue Filing Policy": claims are grounded in actual source — repo rename verified by `remote: https://github.com/ringof/rx888-firmware.git` line on the push, and by direct shields.io URL validation.
- [x] Cross-references resolve: both new badge URLs hit the renamed repo directly.
- [x] Markdown renders correctly — preview locally, badge images load.
- [x] No deprecated commands or removed features touched.

## Reviewer checks

- [ ] Random-spot grep / `Read` of one or two cited file:line references — N/A; no code claims here.
- [ ] No new orphaned or contradictory cross-references introduced.
- [ ] Both badges render in the README header and click through to URLs at `rx888-firmware` directly (no redirect involved).
- [ ] Repo-wide grep on merged main: `grep -rIn "ringof/ExtIO_sddc\|ringof/extio_sddc" .` reports exactly one hit (the patch file flagged above).

## Notes

This PR and PR #100 (Compatible host applications) both touch `README.md` but on disjoint lines (3-4 vs 6-23). Either merge order works without conflict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_