### PR TITLE
test(fx3_cmd): wire gpif_soft_stop and stop_under_backpressure into s…

### DIFF
--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -4658,6 +4658,8 @@ static void usage(const char *prog)
         "  rapid_adc_reprogram          Back-to-back STARTADC freq changes\n"
         "  debug_while_streaming        READINFODEBUG during active stream\n"
         "  abandoned_stream             Simulate host crash (no STOPFX3)\n"
+        "  gpif_soft_stop               Verify SM lands in IDLE (needs new waveform)\n"
+        "  stop_under_backpressure      STOP while DMA buffers full\n"
         "  watchdog_stress [secs]       Observe WDG recovery self-limiting\n"
         "  watchdog_race [rounds]       Provoke EP0-vs-WDG thread race\n"
         "  soak [hours] [seed] [max]    Multi-hour randomized stress test\n"
@@ -4907,6 +4909,12 @@ int main(int argc, char **argv)
 
     } else if (strcmp(cmd, "abandoned_stream") == 0) {
         rc = do_test_abandoned_stream(h);
+
+    } else if (strcmp(cmd, "gpif_soft_stop") == 0) {
+        rc = do_test_gpif_soft_stop(h);
+
+    } else if (strcmp(cmd, "stop_under_backpressure") == 0) {
+        rc = do_test_stop_under_backpressure(h);
 
     } else if (strcmp(cmd, "vendor_rqt_wrap") == 0) {
         rc = do_test_vendor_rqt_wrap(h);


### PR DESCRIPTION
…hell dispatcher

Both functions were defined (tests/fx3_cmd.c:3864, :3938), forward-declared (:529-530), registered in the local debug-console dispatch table (:582-583), and listed in the local help text (:629-630) — but never added to the main shell command-line dispatcher or its usage text.

Result on main: fw_test.sh tests #35 (gpif_soft_stop) and #36 (stop_under_backpressure) invoke ./fx3_cmd <cmd> via shell, hit "unknown command", and FAIL with no useful diagnostic.  Originated from a stacked-PR that split the function implementations and the dispatcher wiring across two branches, with only one half reaching main.

Surgical restore: add two strcmp branches in the main dispatcher and two matching lines in the usage text.  No logic change, no firmware change, +8 lines total.