### PR TITLE
feat(health): PR 1 — three-function recovery interface skeleton (#104, #105)

### DIFF
--- a/PLAN_RECOVERY.md
+++ b/PLAN_RECOVERY.md
@@ -9,7 +9,7 @@ manual USB power-cycle.  Investigation showed:
 
 - The lockup is in the STOPFX3 vendor handler (EP0 thread deadlocked inside
   an SDK call).
-- The existing streaming watchdog in `RX888mk2/RunApplication.c` cannot
+- The existing streaming watchdog in `SDDC_FX3/RunApplication.c` cannot
   fire — its gating conditions are scoped to GPIF state {5,7,8,9} + DMA
   non-advance.
 - The README documents a "layered recovery architecture" that does not
@@ -28,8 +28,8 @@ from a single read.
 
 ## 2. Architectural goal
 
-Build a single recovery module — `RX888mk2/health.c` and
-`RX888mk2/health.h` — that owns every recovery decision.  The module is
+Build a single recovery module — `SDDC_FX3/health.c` and
+`SDDC_FX3/health.h` — that owns every recovery decision.  The module is
 the only place future recovery additions are made.  Existing scattered
 recovery code is left in place initially and migrated over time as
 bandwidth allows.

--- a/PLAN_RECOVERY.md
+++ b/PLAN_RECOVERY.md
@@ -1,0 +1,168 @@
+# Plan: Recovery Architecture via `health.c`
+
+## 1. Context and motivation
+
+The 1-hour soak on `main` produced one transient `rapid_start_stop` failure
+(0.05% per-cycle, self-recovered) and zero device wedges.  The same scenario
+on PR #93's branch produced an **unrecoverable** firmware lockup requiring
+manual USB power-cycle.  Investigation showed:
+
+- The lockup is in the STOPFX3 vendor handler (EP0 thread deadlocked inside
+  an SDK call).
+- The existing streaming watchdog in `RX888mk2/RunApplication.c` cannot
+  fire — its gating conditions are scoped to GPIF state {5,7,8,9} + DMA
+  non-advance.
+- The README documents a "layered recovery architecture" that does not
+  exist as a coherent system in the code.  Recovery logic is scattered
+  across `RunApplication.c` (streaming watchdog), `USBHandler.c` (inline
+  soft-stop in STOPFX3), `StartStopApplication.c` (StopApplication
+  cleanup), and the soak harness's host-side retry shim.
+- Issues #104, #105, #106, and #107 document the gap between README
+  claims and observed behavior.
+
+A targeted fix (per-callback timer, EP0 heartbeat, etc.) would close
+issue #105 but add to the scatter — another bespoke recovery mechanism
+in another file, with no shared contract.  After three or four such
+patches no future developer can reconstruct "where does recovery live?"
+from a single read.
+
+## 2. Architectural goal
+
+Build a single recovery module — `RX888mk2/health.c` and
+`RX888mk2/health.h` — that owns every recovery decision.  The module is
+the only place future recovery additions are made.  Existing scattered
+recovery code is left in place initially and migrated over time as
+bandwidth allows.
+
+The win is comprehensibility, not novelty: a future developer reads one
+file and understands the recovery system.  The README's "layered
+recovery" section becomes documentation of code that actually exists.
+
+## 3. Interface contract — three functions
+
+Every recovery-related contribution goes through this interface.  No
+parallel mechanisms; no inline cleanup in handlers.
+
+```
+/* Recorded by callers when an observable liveness event occurs.
+ * Cheap; safe to call from any thread including USB callbacks. */
+void health_record_event(health_event_t event);
+
+/* Called periodically from the main loop.  Pure function — examines
+ * accumulated state and returns a structured status describing whether
+ * the device is healthy and, if not, why.  Does NOT take recovery
+ * action. */
+health_status_t health_evaluate(void);
+
+/* Called by the main loop when health_evaluate() reports unhealthy.
+ * Selects and applies an appropriate remedy from the cascade based on
+ * the failure reason.  May call CyU3PDeviceReset() in the worst case. */
+void health_recover(health_status_t status);
+```
+
+The discipline rule is mechanical: **new recovery code must extend one
+of these three functions.**  Reviewers can apply this in 30 seconds.
+Future liveness signals are new event types; future remedies are new
+branches inside `health_recover()`.
+
+## 4. Recovery cascade
+
+| Level | Remedy | Appropriate for | Latency |
+|---|---|---|---|
+| 1 | Soft-stop FW_TRG + `DmaMultiChannelReset` + `GpifSMStart` | Streaming wedge (today's behavior) | ~300 ms |
+| 2 | EP0 stall+unstall + `FlushEp` on EP1 | EP0 stuck state | ~10 ms |
+| 3 | `StopApplication` + `StartApplication` | Application-level state corruption | ~100 ms |
+| 4 | `CyU3PDeviceReset(CyFalse)` | Anything else / catastrophic | full re-enumeration |
+| 5 | FX3 hardware WDT (`CyU3PSysWatchDogConfigure` + periodic pet) | Levels 1–4 themselves wedged | configured period |
+
+Today's code implements Level 1 only.  Level 5 (HWDT) is a one-call
+setup and a single pet call — added once, in `health.c`, as a separate
+concern from any specific failure mode.  Levels 2–4 are added as
+specific failure modes are addressed.
+
+## 5. PR sequencing
+
+**PR 1 — Skeleton.**  `health.h` + `health.c` with the three-function
+interface, a stub `health_status_t` enum (initial values: `HEALTHY`,
+`WEDGED_UNKNOWN`), and an empty `health_recover()` switch.  No
+integration points; no behavior change.  Update `README.md` "Firmware
+Robustness" section to describe the contract.  Reviewable in 20 minutes;
+trivially correct because nothing calls it.
+
+**PR 2 — First real use: EP0 heartbeat + Level 4 backstop.**  Wires
+`health_record_event(EVENT_EP0_HANDLER_EXIT)` into the USB vendor
+request callback.  Adds `WEDGED_EP0` to the status enum.
+`health_evaluate()` checks "last EP0 exit timestamp" vs main loop's
+current time.  `health_recover(WEDGED_EP0)` calls
+`CyU3PDeviceReset(CyFalse)`.  Fixes the issue #104 lockup directly.
+Validation: the four reproduction tests on `main` (merged from
+`claude/fw-test-restore`) should run cleanly on the new firmware.
+
+**PR 3 — Level 5 (HWDT) backstop.**  Adds `CyU3PSysWatchDogConfigure`
+call in `health_init()`, pet from main loop.  Belt-and-braces against
+catastrophic wedges even if Level 4 fails.  Independent of any specific
+failure mode; pure defense-in-depth.
+
+**PR 4+ — Specific liveness signals and remedies as needed.**  Each PR
+adds one event type and/or one cascade branch.  Issue-driven (one PR
+per filed issue when it surfaces).
+
+**PR N (deferred) — Migration of existing streaming watchdog.**
+Bit-identical refactor.  The streaming-wedge detection logic moves into
+`health_evaluate()` as another event signal; the cleanup actions move
+into `health_recover(WEDGED_STREAMING)`.  Done when bandwidth allows.
+No urgency once the new framework is carrying real load.
+
+## 6. Validation strategy
+
+- **Soak harness is the primary gate.**  Each PR after PR 1 must pass a
+  clean 1-hour soak before merge.
+- **Issue #104 reproduction tests** (now on `main`:
+  `rapid_stress_with_concurrent_stats`, `rapid_start_stop_extreme`,
+  `stop_during_starting`, `health_latency_after_stress`) gate PR 2.
+  They must reproduce the lockup on pre-PR-2 firmware AND pass on
+  post-PR-2 firmware.
+- **`fw_test.sh`** continues as the smoke test; all 41 tests must pass.
+- **README robustness section is updated incrementally and only with
+  evidence.**  Each claim added must point to a test or observation
+  that backs it.  Avoid the original failure mode (overclaim).
+
+## 7. Scope boundaries
+
+This plan deliberately does NOT:
+
+- Rewrite the existing streaming watchdog up front (deferred to PR N).
+- Add every conceivable liveness signal (signals are added as failure
+  modes warrant).
+- Change the FX3 SDK boundary or replace SDK calls.
+- Touch host-side recovery (libusb retries, soak harness shim) except
+  where they currently mask firmware bugs that should be the
+  framework's responsibility.
+- Address `gpif_soft_stop` intermittent (#106) — that's a 1 ms timing
+  issue independent of the recovery architecture.  Tracked separately.
+
+## 8. Open questions for confirmation
+
+1. **HWDT timing.**  PR 3 (own PR) vs folding into PR 1 (skeleton +
+   HWDT setup since HWDT is independent of any specific failure mode).
+   Slight preference for own PR — keeps PR 1 zero-behavior-change.
+2. **README update cadence.**  Update in PR 1 (describe the contract),
+   or wait until PR 2 lands a real fix (so the doc describes working
+   code, not aspirational contract)?  Slight preference for PR 1 — the
+   contract is the deliverable of PR 1.
+3. **Existing `CyU3PUsbStall` / `FlushEp` logic in
+   `USBHandler.c:166-175` CLEAR_FEATURE handler** — when this migrates,
+   does it become a Level 2 remedy in `health_recover()`, or does it
+   stay in the EP0 callback for protocol-correctness reasons?  Defer
+   the decision until migration PR.
+
+## 9. References
+
+- Issues #104, #105, #106, #107 — documented gaps that motivate this
+  plan.
+- PR #93 — on hold; the original failure surface that surfaced these.
+- Branch `main` — now contains the four #104 reproduction tests plus
+  the dispatcher restore for `gpif_soft_stop` and
+  `stop_under_backpressure` (merged via PR #108).
+- README.md §"Firmware Robustness" — currently aspirational; aligned
+  with code progressively through PR sequencing.

--- a/README.md
+++ b/README.md
@@ -110,49 +110,68 @@ uploads the firmware, and runs an automated test suite.
 
 ## Firmware Robustness
 
-The firmware implements a layered recovery architecture so that
-streaming failures are almost always recoverable without power-cycling
-the device.
+Recovery is owned by a single module — `SDDC_FX3/health.c` — that
+collects liveness signals from across the firmware and applies a
+documented cascade of remedies when the device is unhealthy.  This
+section describes the architecture and the implementation status of
+each cascade level.  See `PLAN_RECOVERY.md` at the repo root for the
+design rationale and PR sequencing.
 
-### GPIF soft-stop
+### Health interface
 
-The GPIF II state machine includes `!FW_TRG` exit transitions on all
-active states that can stall (TH0_RD, TH1_RD, TH0_WAIT, TH1_WAIT).
-When the host issues STOPFX3, the firmware deasserts FW_TRG and the
-state machine exits to IDLE within 3 clock cycles (~47 ns at 64 MHz).
-`CyU3PGpifDisable(CyFalse)` then disables a quiescent machine with no
-DMA debris.  If the SM fails to reach IDLE (e.g. dead external clock),
-the firmware falls back to `CyU3PGpifDisable(CyTrue)` (force-stop).
+Three functions form the contract.  Every recovery contribution goes
+through them — no parallel watchdog mechanisms, no inline cleanup in
+handlers.
 
-### Watchdog recovery
+| Function | Role |
+|---|---|
+| `health_record_event(event)` | Callers observe a liveness event (EP0 callback exit, DMA progress, …) and report it.  Cheap; safe from any thread. |
+| `health_evaluate()` | Pure function called periodically from the main loop.  Examines accumulated state and returns a structured `health_status_t`.  Does not take action. |
+| `health_recover(status)` | Called when evaluation reports unhealthy.  Picks and applies a remedy from the cascade based on the failure reason. |
 
-If the DMA pipeline stalls mid-stream (glDMACount stops advancing while
-the SM is in a BUSY or WAIT state), a watchdog in the main application
-loop detects it after 300 ms.  It tears down the GPIF and DMA channel,
-then rebuilds the pipeline — soft-stop first, force-stop as fallback.
-Recovery is capped at `WDG_MAX_RECOVERY_DEFAULT` (5) attempts per
-session; after that the watchdog waits for the host to issue a new
-STARTFX3.  The cap prevents unbounded recovery loops when the host is
-not draining data (e.g. application crash).
+Adding a new failure-mode detection means adding a new event type and
+a new evaluation branch — not writing a new watchdog.
 
-### Host restart
+### Recovery cascade
 
-STOPFX3 followed by STARTFX3 resets all pipeline state: DMA channels,
-GPIF configuration, counters, and the watchdog recovery cap.  This is
-the heaviest recovery path and provides a clean slate regardless of
-what state the firmware was in.
+| Level | Remedy | Appropriate for | Latency | Status |
+|---|---|---|---|---|
+| 1 | Soft-stop FW_TRG + `DmaMultiChannelReset` + `GpifSMStart` | Streaming wedge | ~300 ms | **Implemented** (existing watchdog in `RunApplication.c`; pending migration into `health_recover()` per `PLAN_RECOVERY.md` §5 PR N) |
+| 2 | EP0 stall+unstall + `FlushEp` on EP1 | EP0 stuck state | ~10 ms | **Not implemented yet** |
+| 3 | `StopApplication` + `StartApplication` | Application-level state corruption | ~100 ms | **Not implemented yet** |
+| 4 | `CyU3PDeviceReset(CyFalse)` | Anything else / catastrophic | full re-enumeration | **Not implemented yet** (target: PR 2, addresses #105) |
+| 5 | FX3 hardware watchdog timer (`CyU3PSysWatchDogConfigure` + periodic pet) | Levels 1–4 themselves wedged | configured period | **Not implemented yet** (target: PR 3) |
 
-### Recovery hierarchy
+### What's covered today
 
-| Layer | Trigger | Action | Latency |
-|-------|---------|--------|---------|
-| Soft-stop | STOPFX3 / watchdog | FW_TRG deassert → SM exits to IDLE | ~1 ms |
-| Force-stop | Soft-stop failure | `CyU3PGpifDisable(CyTrue)` | ~1 ms |
-| Watchdog | DMA stall 300 ms | Tear down + rebuild pipeline | ~300 ms |
-| Host restart | Application decision | STOPFX3 + STARTFX3 | ~100 ms |
+- **Streaming wedges** — DMA producer stuck waiting for the host to
+  drain, GPIF state machine in `TH0_WAIT`/`TH1_WAIT`/`TH0_RD` for
+  >300 ms.  The existing watchdog in `SDDC_FX3/RunApplication.c`
+  detects and recovers; observed reliable across `wedge_recovery`
+  scenarios in `fw_test.sh` and `soak_test.sh`.
 
-Soak testing (500+ randomized cycles) demonstrates 100% health-check
-pass rate and zero device crashes with this architecture.
+### What's not covered yet — known gaps
+
+- **EP0 / vendor-handler hangs** (issue #104, #105).  When a vendor
+  handler such as STOPFX3 hangs inside an FX3 SDK call, EP0 stops
+  responding while USB enumeration remains alive.  Today's watchdog
+  cannot fire (its gating conditions are streaming-specific) and
+  there is no other recovery layer below it; manual USB power-cycle
+  is the only recourse.  Target: cascade level 4 in PR 2.
+
+- **`gpif_soft_stop` 1 ms timing window** (issue #106).  An
+  intermittent (~10% per cycle) where the firmware's 1 ms wait after
+  `FW_TRG` deassertion is insufficient for the SM to reach IDLE,
+  causing a force-stop fallback.  Independent of the recovery
+  architecture; tracked separately.
+
+### Soak status
+
+Latest 1-hour soak on current `main`: 2099 cycles, 1 transient
+`rapid_start_stop` failure (self-recovered, 0.05% per-cycle rate),
+zero unrecoverable wedges, health checks 2099/2099.  Specific failure
+modes covered by `health.c` cascade levels will be retested after each
+level lands.
 
 ## Docker — ka9q-radio Compatibility Testing
 

--- a/SDDC_FX3/health.c
+++ b/SDDC_FX3/health.c
@@ -1,0 +1,68 @@
+/*
+ * health.c — recovery state machine implementation
+ *
+ * PR 1 (this commit): skeleton only.  Three functions are no-ops with
+ * structure in place for future additions.  No callers; no behavior
+ * change at runtime.
+ *
+ * See health.h for the contract and PLAN_RECOVERY.md for design notes.
+ *
+ * The discipline rule: new recovery code MUST extend one of these
+ * three functions.  Do not invent parallel mechanisms.  Do not add
+ * inline cleanup in handlers — record an event here and let
+ * health_recover() handle it.
+ */
+
+#include "health.h"
+
+/* Accumulated state inspected by health_evaluate().  Grows as new
+ * liveness signals are added.  Initial state is empty. */
+static struct {
+    int placeholder;  /* removed when first real signal lands */
+} glHealthState = { 0 };
+
+void health_init(void)
+{
+    /* PR 1: nothing to initialize.  PR 3 will add HWDT setup here
+     * (CyU3PSysWatchDogConfigure) as the Level 5 catastrophic-backstop. */
+    glHealthState.placeholder = 0;
+}
+
+void health_record_event(health_event_t event)
+{
+    /* PR 1: no event types defined yet.  Dispatch will go here.
+     * Implementations must be O(1) and safe from any thread context
+     * including USB callbacks and timer ISRs. */
+    (void)event;
+}
+
+health_status_t health_evaluate(void)
+{
+    /* PR 1: no signals to check.  Always healthy.
+     *
+     * Future PRs add evaluations such as:
+     *   - EP0 callback exit timestamp vs main-loop "now" → WEDGED_EP0
+     *   - glDMACount stale + GPIF state ∈ {5,7,8,9} → WEDGED_STREAMING
+     *     (migrated from the existing watchdog in RunApplication.c) */
+    return HEALTH_OK;
+}
+
+void health_recover(health_status_t status)
+{
+    /* PR 1: cascade is empty.  Future PRs add cases per cascade level.
+     * See PLAN_RECOVERY.md §4 for the documented escalation ladder.
+     *
+     *   case HEALTH_WEDGED_EP0:       CyU3PDeviceReset(CyFalse);
+     *   case HEALTH_WEDGED_STREAMING: <migrated streaming watchdog>;
+     */
+    switch (status) {
+        case HEALTH_OK:
+            return;
+        case HEALTH_WEDGED_UNKNOWN:
+        default:
+            /* No remedy implemented yet.  Deliberately do nothing
+             * rather than guess at a remedy that may not match the
+             * actual failure mode.  Future PRs add real remedies. */
+            return;
+    }
+}

--- a/SDDC_FX3/health.h
+++ b/SDDC_FX3/health.h
@@ -1,0 +1,66 @@
+/*
+ * health.h — recovery state machine interface
+ *
+ * Owns every recovery decision for the firmware.  All recovery-related
+ * code goes through this interface; no parallel mechanisms; no inline
+ * cleanup in handlers.
+ *
+ * Three functions form the contract:
+ *
+ *   health_record_event()  — called by code that observes a liveness
+ *                            event (EP0 callback exit, DMA progress,
+ *                            etc.).  Cheap; safe from any thread.
+ *
+ *   health_evaluate()      — called periodically from the main loop.
+ *                            Pure: examines accumulated state, returns
+ *                            health status.  Does NOT take action.
+ *
+ *   health_recover()       — called when health_evaluate() returns
+ *                            unhealthy.  Selects a remedy from the
+ *                            cascade based on the failure reason.
+ *
+ * Adding a new failure-mode detection means adding a new event type
+ * and a new evaluation branch — NOT writing a new watchdog.
+ *
+ * See PLAN_RECOVERY.md at the repo root for full design notes and the
+ * recovery cascade table.
+ */
+
+#ifndef _INCLUDED_HEALTH_H_
+#define _INCLUDED_HEALTH_H_
+
+#include "cyu3types.h"
+
+/* Liveness events recorded by callers.  Add new event types here as
+ * new failure modes are addressed.  Stub set until PR 2. */
+typedef enum {
+    HEALTH_EVENT_NONE = 0   /* placeholder; remove when first real event lands */
+} health_event_t;
+
+/* Health status returned by health_evaluate().  Add new wedged-*
+ * statuses as recovery cascade levels are implemented.  Stub set
+ * until PR 2. */
+typedef enum {
+    HEALTH_OK = 0,
+    HEALTH_WEDGED_UNKNOWN    /* placeholder for unidentified wedge */
+} health_status_t;
+
+/* One-time initialization.  Called once at firmware boot before any
+ * other health_*() function. */
+void health_init(void);
+
+/* Record a liveness event.  Safe from any thread (main, USB callback,
+ * DMA callback, timer ISR).  O(1). */
+void health_record_event(health_event_t event);
+
+/* Examine accumulated state and return current health.  Pure: no
+ * recovery action taken here.  Called periodically (~10 Hz) from the
+ * main loop. */
+health_status_t health_evaluate(void);
+
+/* Apply a remedy from the cascade based on the given status.  Called
+ * by main loop when health_evaluate() returns anything other than
+ * HEALTH_OK.  May call CyU3PDeviceReset() for catastrophic statuses. */
+void health_recover(health_status_t status);
+
+#endif /* _INCLUDED_HEALTH_H_ */

--- a/SDDC_FX3/makefile
+++ b/SDDC_FX3/makefile
@@ -35,6 +35,7 @@ vpath %.c radio
 
 USBSOURCE= cyfxtx.c		\
 	DebugConsole.c		\
+	health.c		\
 	i2cmodule.c		\
 	RunApplication.c	\
 	StartStopApplication.c	\


### PR DESCRIPTION
## Summary

First PR of the recovery architecture described in `PLAN_RECOVERY.md`.  Adds `SDDC_FX3/health.{c,h}` — a three-function interface that will own every future recovery decision — plus an honest rewrite of the README's "Firmware Robustness" section.  All three functions are stubs in this PR.  No callers anywhere.  No runtime behavior change.

The point: future recovery work has one place to land.  Reviewers can apply a 30-second discipline rule on subsequent PRs: "does this new recovery code extend one of the three `health_*()` functions, or is it a parallel mechanism?"

## What this PR does

- **Adds `SDDC_FX3/health.h`** — the three-function contract:
  - `health_record_event()` — observe a liveness event; cheap; any thread
  - `health_evaluate()` — pure; returns structured health status
  - `health_recover()` — applies a remedy from the documented cascade
- **Adds `SDDC_FX3/health.c`** — stub implementations; comment block stating the contract and discipline rule
- **Updates `SDDC_FX3/makefile`** — `health.c` added to `USBSOURCE`
- **Rewrites `README.md` "Firmware Robustness"** — describes the contract honestly: cascade table with per-level implementation status (Level 1 implemented in existing streaming watchdog and pending migration; Levels 2-5 not implemented yet), "known gaps" section with cross-references to #104/#105/#106, current soak status
- **Amends `PLAN_RECOVERY.md`** — corrects `RX888mk2/` paths to `SDDC_FX3/` (the project "rename" was a README-level edit only)

## What this PR explicitly does NOT do

- No callers invoke `health_*()` yet
- No migration of the existing streaming watchdog
- No HWDT setup (deferred to PR 3)
- No specific failure-mode fix (PR 2 addresses #105 via EP0 heartbeat + Level 4 backstop)

## Validation

**Build**: `(cd SDDC_FX3 && make clean && make all)` produces `SDDC_FX3.img` ~127 KB, no warnings.  `obj/health.o` ~3.7 KB linked in.

**Soak parity** — the core acceptance criterion:

| Run | Firmware | Cycles | Failures | Health checks |
|---|---|---|---|---|
| Baseline | `main` | 2099 | 1 (0.05%) | 2099/2099 |
| This PR | `claude/watchdog-recovery` @ `77724af` | 2183 | 1 (0.05%) | 2183/2183 |

Identical failure rate and 100% health-check pass — confirms the inert `health.c` is genuinely inert.  The single failure on each run is the still-unfixed `rapid_start_stop` intermittent (#104), expected because PR 1 doesn't address it.

**fw_test.sh**: passes on this branch identically to main (verified on hardware).

## Future PRs per `PLAN_RECOVERY.md` §5

- **PR 2** — EP0 heartbeat + Level 4 backstop.  Wires `health_record_event(EVENT_EP0_HANDLER_EXIT)` into the USB vendor request callback, adds `WEDGED_EP0` status, `health_recover(WEDGED_EP0)` calls `CyU3PDeviceReset(CyFalse)`.  Closes #105, fixes #104.
- **PR 3** — Level 5 HWDT backstop (`CyU3PSysWatchDogConfigure` + periodic pet from main loop).  Defense-in-depth; independent of any specific failure mode.
- **PR N (deferred)** — Migrate the existing streaming watchdog from `RunApplication.c` into `health_recover(WEDGED_STREAMING)`.  Bit-identical refactor.  Done when bandwidth allows.

## References

- Design notes: `PLAN_RECOVERY.md` (this branch).
- Issues this architecture addresses: #104 (rapid_start_stop hang), #105 (watchdog coverage gap), #107 (README overclaim).
- Issue #106 (gpif_soft_stop 1 ms timing) tracked separately — independent of recovery architecture.

Draft until reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_