### PR TITLE
feat(health): PR 2 — EP0 heartbeat + Level 4 backstop + HANGFX3 deterministic test (#104, #105)

### DIFF
--- a/SDDC_FX3/RunApplication.c
+++ b/SDDC_FX3/RunApplication.c
@@ -13,6 +13,8 @@
 
 #include "Si5351.h"
 
+#include "health.h"
+
 #define R828D_I2C_ADDR		0x74
 
 #include "radio.h"
@@ -311,6 +313,20 @@ void ApplicationThread ( uint32_t input)
 					}
 				}
 
+				/* Health watchdog (Level 4 backstop, issues #104, #105).
+				 * Evaluated outside the glIsApplnActive check so EP0
+				 * hangs during enumeration are caught too.  On
+				 * HEALTH_WEDGED_EP0, health_recover() calls
+				 * CyU3PDeviceReset() — that does not return. */
+				{
+					health_status_t hs = health_evaluate();
+					if (hs != HEALTH_OK)
+					{
+						DebugPrint(4, "\r\nHEALTH: status=%d, recovering", hs);
+						health_recover(hs);
+					}
+				}
+
 #ifndef _DEBUG_USB_  // second count in serial debug
 				if (glDMACount > 7812)
 				{
@@ -335,6 +351,9 @@ void CyFxApplicationDefine (void) {
     // Create any needed resources then the Application thread
     Status = InitializeDebugConsole();
     CheckStatus("Initialize Debug Console", Status);
+
+    // Initialize the recovery state machine (no-op for events not yet wired).
+    health_init();
 
     // Create Queue used to transfer callback messages
         Status = CyU3PQueueCreate(&glEventAvailable, 1, &glEventAvailableQueue, sizeof(glEventAvailableQueue));

--- a/SDDC_FX3/USBHandler.c
+++ b/SDDC_FX3/USBHandler.c
@@ -186,6 +186,9 @@ CyFxSlFifoApplnUSBSetupCB (
     	/* Reject oversized EP0 data before any GetEP0Data call. */
     	if (wLength > CYFX_SDRAPP_MAX_EP0LEN) {
     		CyU3PUsbStall(0, CyTrue, CyFalse);
+    		/* Match the ENTER recorded at the top of this function so the
+    		 * health watchdog doesn't see an apparent stuck handler. */
+    		health_record_event(HEALTH_EVENT_EP0_HANDLER_EXIT);
     		return CyTrue;
     	}
 

--- a/SDDC_FX3/USBHandler.c
+++ b/SDDC_FX3/USBHandler.c
@@ -16,6 +16,8 @@
 
 #include "radio.h"
 
+#include "health.h"
+
 // Declare external functions
 extern void CheckStatus(char* StringPtr, CyU3PReturnStatus_t Status);
 extern void StartApplication(void);
@@ -119,6 +121,10 @@ CyFxSlFifoApplnUSBSetupCB (
     uint16_t wLength;
     CyBool_t isHandled = CyFalse;
     CyU3PReturnStatus_t apiRetStatus;
+
+    /* Liveness: record callback entry for the health watchdog.  Matched
+     * by HEALTH_EVENT_EP0_HANDLER_EXIT at every return path below. */
+    health_record_event(HEALTH_EVENT_EP0_HANDLER_ENTER);
 
     /* Decode the fields from the setup request. */
     bReqType = (setupdat0 & CY_U3P_USB_REQUEST_TYPE_MASK);
@@ -428,6 +434,26 @@ CyFxSlFifoApplnUSBSetupCB (
 					isHandled = CyTrue;
 					break;
 
+				/* TEST-ONLY: deterministically wedge the EP0 handler by
+				 * sleeping wValue milliseconds in this thread context.
+				 * The health watchdog (see RunApplication.c + health.c)
+				 * should detect the hang at EP0_HANDLER_TIMEOUT_MS and
+				 * call CyU3PDeviceReset(CyFalse).  Used by the host-side
+				 * test_health_recovery scenario to validate Level-4
+				 * recovery end-to-end.  Issues #104, #105. */
+				case HANGFX3:
+					{
+						uint32_t hang_ms = (uint32_t)wValue;
+						DebugPrint(4, "\r\nHANGFX3: sleeping %u ms (test-only)", hang_ms);
+						CyU3PThreadSleep(hang_ms);
+						/* If we reach here the watchdog did NOT fire — wValue
+						 * was shorter than the timeout.  Acknowledge so the
+						 * host doesn't see a STALL. */
+						CyU3PUsbAckSetup();
+						isHandled = CyTrue;
+					}
+					break;
+
 
 	   case READINFODEBUG:
 					{
@@ -479,6 +505,9 @@ CyFxSlFifoApplnUSBSetupCB (
     	}
     	TraceSerial( bRequest, (uint8_t *) &glEp0Buffer[0], wValue, wIndex);
     }
+    /* Liveness: record callback exit so the health watchdog stops the
+     * timeout window started at HEALTH_EVENT_EP0_HANDLER_ENTER. */
+    health_record_event(HEALTH_EVENT_EP0_HANDLER_EXIT);
     return isHandled;
 }
 

--- a/SDDC_FX3/health.c
+++ b/SDDC_FX3/health.c
@@ -1,9 +1,8 @@
 /*
  * health.c — recovery state machine implementation
  *
- * PR 1 (this commit): skeleton only.  Three functions are no-ops with
- * structure in place for future additions.  No callers; no behavior
- * change at runtime.
+ * PR 2: adds EP0 vendor-callback liveness tracking and Level 4
+ * (CyU3PDeviceReset) backstop.  Addresses issues #104, #105.
  *
  * See health.h for the contract and PLAN_RECOVERY.md for design notes.
  *
@@ -14,55 +13,92 @@
  */
 
 #include "health.h"
+#include "cyu3os.h"
+#include "cyu3system.h"
 
-/* Accumulated state inspected by health_evaluate().  Grows as new
- * liveness signals are added.  Initial state is empty. */
+/* If an EP0 vendor callback runs longer than this, declare it wedged
+ * and reset the device.  Legitimate handlers complete in <100 ms
+ * (longest observed: STOPFX3 soft-stop ~5 ms incl. 1 ms ThreadSleep).
+ * Host's libusb_control_transfer times out at 1000 ms (CTRL_TIMEOUT_MS
+ * in tests/fx3_cmd.c), so 2000 ms gives ~1 s after host gives up
+ * before we hard-reset. */
+#define EP0_HANDLER_TIMEOUT_MS  2000
+
+/* Accumulated state inspected by health_evaluate().  Written by the
+ * USB callback thread, read by the main loop.  Single-byte/word
+ * accesses are atomic on ARM926; volatile prevents compiler reordering.
+ * Ordering rule: writers update timestamp BEFORE setting in_progress,
+ * so a reader never sees in_progress=1 with a stale enter_ms. */
 static struct {
-    int placeholder;  /* removed when first real signal lands */
-} glHealthState = { 0 };
+    volatile uint32_t ep0_handler_enter_ms;
+    volatile uint8_t  ep0_handler_in_progress;
+} glHealthState = { 0, 0 };
 
 void health_init(void)
 {
-    /* PR 1: nothing to initialize.  PR 3 will add HWDT setup here
-     * (CyU3PSysWatchDogConfigure) as the Level 5 catastrophic-backstop. */
-    glHealthState.placeholder = 0;
+    /* PR 3 will add HWDT setup here (CyU3PSysWatchDogConfigure) as the
+     * Level 5 catastrophic-backstop. */
+    glHealthState.ep0_handler_enter_ms = 0;
+    glHealthState.ep0_handler_in_progress = 0;
 }
 
 void health_record_event(health_event_t event)
 {
-    /* PR 1: no event types defined yet.  Dispatch will go here.
-     * Implementations must be O(1) and safe from any thread context
-     * including USB callbacks and timer ISRs. */
-    (void)event;
+    /* O(1).  Safe from any thread context including USB callbacks
+     * and timer ISRs.  All branches must remain non-blocking. */
+    switch (event) {
+        case HEALTH_EVENT_EP0_HANDLER_ENTER:
+            /* Order matters: stamp time first, then raise flag, so a
+             * reader observing in_progress=1 always sees a fresh
+             * enter_ms (volatile blocks compiler reorder). */
+            glHealthState.ep0_handler_enter_ms = CyU3PGetTime();
+            glHealthState.ep0_handler_in_progress = 1;
+            break;
+        case HEALTH_EVENT_EP0_HANDLER_EXIT:
+            glHealthState.ep0_handler_in_progress = 0;
+            break;
+    }
 }
 
 health_status_t health_evaluate(void)
 {
-    /* PR 1: no signals to check.  Always healthy.
-     *
-     * Future PRs add evaluations such as:
-     *   - EP0 callback exit timestamp vs main-loop "now" → WEDGED_EP0
-     *   - glDMACount stale + GPIF state ∈ {5,7,8,9} → WEDGED_STREAMING
-     *     (migrated from the existing watchdog in RunApplication.c) */
+    /* PR 2: one signal — EP0 handler duration vs timeout. */
+    if (glHealthState.ep0_handler_in_progress) {
+        uint32_t now = CyU3PGetTime();
+        uint32_t enter = glHealthState.ep0_handler_enter_ms;
+        /* Unsigned subtraction is wraparound-safe for any handler that
+         * actually completes within ~24 days (CyU3PGetTime ms rollover). */
+        if ((now - enter) >= EP0_HANDLER_TIMEOUT_MS) {
+            return HEALTH_WEDGED_EP0;
+        }
+    }
     return HEALTH_OK;
 }
 
 void health_recover(health_status_t status)
 {
-    /* PR 1: cascade is empty.  Future PRs add cases per cascade level.
-     * See PLAN_RECOVERY.md §4 for the documented escalation ladder.
-     *
-     *   case HEALTH_WEDGED_EP0:       CyU3PDeviceReset(CyFalse);
-     *   case HEALTH_WEDGED_STREAMING: <migrated streaming watchdog>;
-     */
+    /* See PLAN_RECOVERY.md §4 for the documented cascade levels.
+     * PR 2 implements Level 4 only.  Future PRs add Levels 2, 3, 5
+     * and migrate Level 1 (streaming watchdog). */
     switch (status) {
+        case HEALTH_WEDGED_EP0:
+            /* Level 4 — full device reset.  The vendor callback thread
+             * is deadlocked inside an SDK call; only escape is to drop
+             * USB entirely and re-enumerate.  Host will see disconnect
+             * + bootloader-PID device; firmware must be re-uploaded.
+             * No DebugPrint before reset — UART output is fine but the
+             * SDK call may itself be the thing hung, so avoid waiting. */
+            CyU3PDeviceReset(CyFalse);
+            /* Should not return. */
+            break;
+
         case HEALTH_OK:
-            return;
         case HEALTH_WEDGED_UNKNOWN:
         default:
-            /* No remedy implemented yet.  Deliberately do nothing
-             * rather than guess at a remedy that may not match the
-             * actual failure mode.  Future PRs add real remedies. */
+            /* No remedy for unknown wedge — deliberately do nothing
+             * rather than guess.  Future PRs may add a catch-all
+             * remedy (e.g. cascade through Levels 2 -> 3 -> 4) once
+             * we have signals that can produce HEALTH_WEDGED_UNKNOWN. */
             return;
     }
 }

--- a/SDDC_FX3/health.h
+++ b/SDDC_FX3/health.h
@@ -32,17 +32,18 @@
 #include "cyu3types.h"
 
 /* Liveness events recorded by callers.  Add new event types here as
- * new failure modes are addressed.  Stub set until PR 2. */
+ * new failure modes are addressed. */
 typedef enum {
-    HEALTH_EVENT_NONE = 0   /* placeholder; remove when first real event lands */
+    HEALTH_EVENT_EP0_HANDLER_ENTER = 0,  /* USB vendor callback entered */
+    HEALTH_EVENT_EP0_HANDLER_EXIT,       /* USB vendor callback returned */
 } health_event_t;
 
 /* Health status returned by health_evaluate().  Add new wedged-*
- * statuses as recovery cascade levels are implemented.  Stub set
- * until PR 2. */
+ * statuses as recovery cascade levels are implemented. */
 typedef enum {
     HEALTH_OK = 0,
-    HEALTH_WEDGED_UNKNOWN    /* placeholder for unidentified wedge */
+    HEALTH_WEDGED_EP0,        /* Vendor callback hung in SDK call (issue #104, #105) */
+    HEALTH_WEDGED_UNKNOWN,    /* Unidentified wedge — fall-through case */
 } health_status_t;
 
 /* One-time initialization.  Called once at firmware boot before any

--- a/SDDC_FX3/protocol.h
+++ b/SDDC_FX3/protocol.h
@@ -23,6 +23,13 @@ enum FX3Command {
     GETSTATS      = 0xB3,   /* Read diagnostic counters (read-only) */
     SETARGFX3     = 0xB6,   /* Set argument by index/value */
     READINFODEBUG = 0xBA,   /* Read debug output / send debug input */
+    HANGFX3       = 0xCE,   /* TEST-ONLY: sleep wValue ms in the EP0 handler
+                             * to deterministically wedge the vendor callback.
+                             * Used by tests/fx3_cmd.c test_health_recovery to
+                             * validate the health watchdog's Level-4 reset
+                             * (issues #104, #105).  Safe in production: the
+                             * watchdog auto-resets the device if invoked
+                             * with wValue >= EP0_HANDLER_TIMEOUT_MS. */
 };
 
 /* GPIO bit masks for GPIOFX3 control word (active-low/high depends on pin) */

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -56,6 +56,9 @@
 #define SETARGFX3     0xB6
 #define TUNERSTDBY    0xB8
 #define READINFODEBUG 0xBA
+#define HANGFX3       0xCE   /* TEST-ONLY: sleep wValue ms in EP0 handler;
+                              * used by test_health_recovery to trip the
+                              * firmware health watchdog (#104, #105). */
 
 /* SETARGFX3 argument IDs */
 #define DAT31_ATT     10
@@ -68,6 +71,7 @@
 /* Global libusb context — needed by primed_start_and_read() for
  * libusb_handle_events_timeout_completed().  Set once in main(). */
 static libusb_context *g_ctx;
+static const char *g_firmware_path = NULL;  /* set from -F option in main() */
 
 /* ------------------------------------------------------------------ */
 /* USB helpers (patterns from rx888_stream.c)                         */
@@ -528,6 +532,7 @@ static int do_test_adc_freq_extremes(libusb_device_handle *h);
 static int do_test_data_sanity(libusb_device_handle *h);
 static int do_test_gpif_soft_stop(libusb_device_handle *h);
 static int do_test_stop_under_backpressure(libusb_device_handle *h);
+static int do_test_health_recovery(libusb_device_handle *h);
 
 /* No-arg command table entry */
 struct local_cmd_entry {
@@ -581,6 +586,7 @@ static const struct local_cmd_entry local_cmds_noarg[] = {
     {"data_sanity",      do_test_data_sanity},
     {"gpif_soft_stop",   do_test_gpif_soft_stop},
     {"stop_under_backpressure", do_test_stop_under_backpressure},
+    {"test_health_recovery", do_test_health_recovery},
     {"reset",            do_reset},
     {NULL, NULL}
 };
@@ -628,6 +634,7 @@ static void print_local_help(void)
            "  data_sanity                   Bulk data corruption check\n"
            "  gpif_soft_stop                Verify SM lands in IDLE (needs new waveform)\n"
            "  stop_under_backpressure       STOP while DMA buffers full\n"
+           "  test_health_recovery          HANGFX3 + watchdog reset round-trip (#104, #105)\n"
            "  pib_overflow                  Provoke + detect PIB error\n"
            "  stack_check                   Query stack watermark\n"
            "  i2cr <addr> <reg> <len>       I2C read (hex)\n"
@@ -4597,6 +4604,117 @@ static int soak_main(libusb_device_handle *h, int argc, char **argv)
 }
 
 /* ------------------------------------------------------------------ */
+/* test_health_recovery — end-to-end validation of health.c Level-4    */
+/*                                                                     */
+/* Issues HANGFX3(wValue=5000) which deterministically wedges the EP0  */
+/* vendor callback for 5 seconds (the handler does CyU3PThreadSleep).  */
+/* The firmware health watchdog should detect the hang at              */
+/* EP0_HANDLER_TIMEOUT_MS (~2s) and call CyU3PDeviceReset(CyFalse),    */
+/* which drops USB and leaves the device in bootloader mode.  Test     */
+/* verifies device re-enumerates to bootloader, re-uploads firmware,   */
+/* and confirms normal operation resumes.                              */
+/*                                                                     */
+/* Requires -F <firmware.img> on the fx3_cmd command line so the test  */
+/* can re-upload after the reset.  Issues #104, #105.                  */
+/* ------------------------------------------------------------------ */
+static int do_test_health_recovery(libusb_device_handle *h)
+{
+    int r;
+    uint8_t buf[4];
+
+    /* 1. Confirm device is healthy before the test */
+    r = ctrl_read(h, TESTFX3, 0, 0, buf, 4);
+    if (r < 0) {
+        printf("FAIL test_health_recovery: precheck TESTFX3: %s\n",
+               libusb_strerror(r));
+        return 1;
+    }
+
+    if (!g_firmware_path) {
+        printf("FAIL test_health_recovery: requires -F <firmware.img> "
+               "to re-upload after watchdog reset\n");
+        return 1;
+    }
+
+    printf("# test_health_recovery: issuing HANGFX3(5000 ms)\n");
+    printf("#   expected: host libusb times out at %d ms, firmware watchdog\n",
+           CTRL_TIMEOUT_MS);
+    printf("#   fires at ~2 s, device re-enumerates to bootloader PID 0x%04X\n",
+           RX888_PID_BOOT);
+
+    /* 2. Issue HANGFX3 with wValue=5000 (5 second hang).  No data phase. */
+    r = libusb_control_transfer(
+        h,
+        LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
+        HANGFX3, 5000, 0, NULL, 0, CTRL_TIMEOUT_MS);
+
+    /* Expected: TIMEOUT because firmware is wedged in CyU3PThreadSleep
+     * and never ACKs the SETUP.  Any other result means the hang didn't
+     * happen — either HANGFX3 isn't wired up (firmware needs flashing)
+     * or the firmware completed the sleep faster than 1 s. */
+    if (r != LIBUSB_ERROR_TIMEOUT) {
+        printf("FAIL test_health_recovery: HANGFX3 expected LIBUSB_ERROR_TIMEOUT, "
+               "got %d (%s)\n", r, libusb_strerror(r));
+        return 1;
+    }
+    printf("# HANGFX3 returned TIMEOUT as expected; waiting for watchdog reset...\n");
+
+    /* 3. Wait for firmware health watchdog to fire and reset device.
+     * Watchdog timeout 2000 ms + 100 ms poll cadence + USB re-enumeration
+     * settle ~1-2 s = ~4 s total worst-case. */
+    sleep(4);
+
+    /* 4. Verify device is in bootloader mode — proof that
+     * CyU3PDeviceReset() fired from health_recover(WEDGED_EP0). */
+    libusb_device_handle *bl =
+        libusb_open_device_with_vid_pid(g_ctx, RX888_VID, RX888_PID_BOOT);
+    if (!bl) {
+        /* Try app PID just in case timing was off and it came back fast */
+        libusb_device_handle *app =
+            libusb_open_device_with_vid_pid(g_ctx, RX888_VID, RX888_PID_APP);
+        if (app) {
+            libusb_close(app);
+            printf("FAIL test_health_recovery: device found at APP PID, not "
+                   "bootloader — watchdog may not have fired, or firmware "
+                   "came back without bootloader transition\n");
+        } else {
+            printf("FAIL test_health_recovery: device not visible at either PID "
+                   "after 4 s wait — watchdog did not reset, or device "
+                   "is in a deeper wedge state requiring USB power-cycle\n");
+        }
+        return 1;
+    }
+    libusb_close(bl);
+    printf("# device found at bootloader PID — health watchdog fired correctly\n");
+
+    /* 5. Re-upload firmware via the existing upload_firmware helper */
+    if (upload_firmware(g_ctx, g_firmware_path) != 0) {
+        printf("FAIL test_health_recovery: firmware re-upload failed\n");
+        return 1;
+    }
+
+    /* 6. Verify normal operation resumes */
+    libusb_device_handle *running =
+        libusb_open_device_with_vid_pid(g_ctx, RX888_VID, RX888_PID_APP);
+    if (!running) {
+        printf("FAIL test_health_recovery: device not at APP PID after re-upload\n");
+        return 1;
+    }
+    r = ctrl_read(running, TESTFX3, 0, 0, buf, 4);
+    libusb_close(running);
+    if (r < 0) {
+        printf("FAIL test_health_recovery: post-recovery TESTFX3: %s\n",
+               libusb_strerror(r));
+        return 1;
+    }
+
+    printf("PASS test_health_recovery: HANGFX3 -> watchdog reset -> bootloader "
+           "-> firmware re-uploaded -> device alive (hwconfig=0x%02X fw=%d.%d)\n",
+           buf[0], buf[1], buf[2]);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
 /* Usage and main                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -4660,6 +4778,8 @@ static void usage(const char *prog)
         "  abandoned_stream             Simulate host crash (no STOPFX3)\n"
         "  gpif_soft_stop               Verify SM lands in IDLE (needs new waveform)\n"
         "  stop_under_backpressure      STOP while DMA buffers full\n"
+        "  test_health_recovery         HANGFX3 + watchdog reset round-trip (#104, #105;\n"
+        "                                 requires -F <firmware.img> for post-reset re-upload)\n"
         "  watchdog_stress [secs]       Observe WDG recovery self-limiting\n"
         "  watchdog_race [rounds]       Provoke EP0-vs-WDG thread race\n"
         "  soak [hours] [seed] [max]    Multi-hour randomized stress test\n"
@@ -4712,6 +4832,9 @@ int main(int argc, char **argv)
         return 1;
     }
     g_ctx = ctx;
+    g_firmware_path = firmware_path;  /* tests that re-upload firmware
+                                       * (e.g. test_health_recovery) need
+                                       * this — set NULL if -F not given. */
 
     /* ---- Handle "load" command (upload-only, no app-mode device needed) ---- */
     if (strcmp(cmd, "load") == 0) {
@@ -4915,6 +5038,9 @@ int main(int argc, char **argv)
 
     } else if (strcmp(cmd, "stop_under_backpressure") == 0) {
         rc = do_test_stop_under_backpressure(h);
+
+    } else if (strcmp(cmd, "test_health_recovery") == 0) {
+        rc = do_test_health_recovery(h);
 
     } else if (strcmp(cmd, "vendor_rqt_wrap") == 0) {
         rc = do_test_vendor_rqt_wrap(h);

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -4636,6 +4636,26 @@ static int do_test_health_recovery(libusb_device_handle *h)
         return 1;
     }
 
+    /* Resolve firmware path early so a missing/bad path fails BEFORE we
+     * trip the watchdog and leave the device in bootloader.  Try the
+     * given path first; fall back to a conventional relative location
+     * when invoked from tests/ (where ../SDDC_FX3/SDDC_FX3.img is the
+     * usual layout). */
+    const char *fw = g_firmware_path;
+    if (access(fw, R_OK) != 0) {
+        const char *fallback = "../SDDC_FX3/SDDC_FX3.img";
+        if (access(fallback, R_OK) == 0) {
+            printf("# firmware path '%s' not readable here; using fallback '%s'\n",
+                   fw, fallback);
+            fw = fallback;
+        } else {
+            printf("FAIL test_health_recovery: firmware path '%s' not readable "
+                   "(also tried '%s').  Use -F <firmware.img> with a path that "
+                   "resolves from your current working directory.\n", fw, fallback);
+            return 1;
+        }
+    }
+
     printf("# test_health_recovery: issuing HANGFX3(5000 ms)\n");
     printf("#   expected: host libusb times out at %d ms, firmware watchdog\n",
            CTRL_TIMEOUT_MS);
@@ -4688,8 +4708,11 @@ static int do_test_health_recovery(libusb_device_handle *h)
     printf("# device found at bootloader PID — health watchdog fired correctly\n");
 
     /* 5. Re-upload firmware via the existing upload_firmware helper */
-    if (upload_firmware(g_ctx, g_firmware_path) != 0) {
-        printf("FAIL test_health_recovery: firmware re-upload failed\n");
+    if (upload_firmware(g_ctx, fw) != 0) {
+        printf("FAIL test_health_recovery: firmware re-upload failed.\n"
+               "#   Device is in bootloader mode (PID 0x%04X).  Recover with:\n"
+               "#       ./fx3_cmd load <path-to-SDDC_FX3.img>\n",
+               RX888_PID_BOOT);
         return 1;
     }
 

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -3617,19 +3617,18 @@ static int do_test_watchdog_cap_restart(libusb_device_handle *h)
     /* Wait for watchdog to hit cap */
     sleep(5);
 
-    /* STOP then restart (clean path) */
+    /* STOP then restart (clean path).  Use the primed retry primitive
+     * (queues bulk TD before STARTFX3, recovers from xHCI EP1 error
+     * state via clear_halt) — same pattern as wedge_recovery and
+     * sustained_stream.  The unprimed bulk_read_some that lived here
+     * before races the GPIF producer at 64 MS/s and lands the host
+     * xHCI endpoint in an error state on every other run (bistable
+     * 50/50 alternation).  The firmware is innocent; the test was the
+     * outlier among streaming-recovery scenarios. */
     cmd_u32(h, STOPFX3, 0);
     usleep(200000);
 
-    r = cmd_u32(h, STARTFX3, 0);
-    if (r < 0) {
-        printf("FAIL watchdog_cap_restart: STARTFX3 #2 after cap: %s\n",
-               libusb_strerror(r));
-        set_arg(h, WDG_MAX_RECOV, 5);
-        return 1;
-    }
-
-    int got = bulk_read_some(h, 16384, 2000);
+    int got = primed_start_and_read_retry(h, 16384, 2000);
     cmd_u32(h, STOPFX3, 0);
     set_arg(h, WDG_MAX_RECOV, 5);
 


### PR DESCRIPTION
## Summary

Second PR of the recovery architecture (`PLAN_RECOVERY.md` §5).  Wires the first real liveness signal — EP0 vendor-handler duration — and implements cascade Level 4 (`CyU3PDeviceReset`).  Closes #105, fixes #104.

Ships with a deterministic test (`test_health_recovery` + the firmware-side `HANGFX3` command) so this PR is validated on demand rather than waiting for the intermittent to surface organically.

## What this PR does

**Firmware (`SDDC_FX3/`)**:

- `health.h` — replaces stub enums with `HEALTH_EVENT_EP0_HANDLER_ENTER`/`EXIT` and `HEALTH_WEDGED_EP0`.
- `health.c` — tracks `ep0_handler_enter_ms` + `in_progress` flag (volatile, ARM926 single-word atomic; writers stamp time BEFORE raising flag to avoid stale-timestamp race).  `health_evaluate()` returns `HEALTH_WEDGED_EP0` if a handler has been running >`EP0_HANDLER_TIMEOUT_MS` (2000 ms).  `health_recover(HEALTH_WEDGED_EP0)` calls `CyU3PDeviceReset(CyFalse)`.
- `USBHandler.c` — hooks `HEALTH_EVENT_EP0_HANDLER_ENTER` at top of `CyFxSlFifoApplnUSBSetupCB`, `_EXIT` at **both** return paths (the bottom-of-function return AND the early `return CyTrue` on EP0 oversize at line 189).  Adds `HANGFX3` (`0xCE`) test-only vendor command: handler does `CyU3PThreadSleep(wValue ms)` to deterministically wedge the EP0 callback.  Safe in production — the watchdog auto-resets on any `wValue >= EP0_HANDLER_TIMEOUT_MS`.
- `RunApplication.c` — calls `health_init()` at boot; calls `health_evaluate()` + `health_recover()` every 100 ms in the main loop, **outside** the `glIsApplnActive` guard so EP0 hangs during enumeration are caught too.
- `protocol.h` — `HANGFX3` enum entry with documentation.

**Host (`tests/fx3_cmd.c`)**:

- `HANGFX3` macro mirroring the firmware enum.
- `g_firmware_path` global set from the existing `-F` option.
- `do_test_health_recovery`: end-to-end validation that issues `HANGFX3(5000)`, expects `LIBUSB_ERROR_TIMEOUT` at 1 s, waits 4 s, verifies device transitioned to bootloader PID `0x00F3`, re-uploads firmware via existing `upload_firmware()` helper, confirms `TESTFX3` succeeds.  UX: pre-flight checks the `-F` firmware path is readable BEFORE issuing `HANGFX3` (with `../SDDC_FX3/SDDC_FX3.img` fallback when run from `tests/`); FAIL message after a successful watchdog reset includes the exact `./fx3_cmd load <path>` recovery command.
- `do_test_watchdog_cap_restart` migrated from unprimed `cmd_u32(STARTFX3) + bulk_read_some` to `primed_start_and_read_retry`.  Same primitive `wedge_recovery` and `sustained_stream` use.  Eliminates a 50/50 bistable race at 64 MS/s that the soak surfaced when validating this PR.

## Validation evidence

**Hardware tests on RX888mk2 reference, all PASS:**

```
$ ./fx3_cmd ep0_overflow
PASS ep0_overflow: STALL on wLength=128 (> 64)

$ ./fx3_cmd ep0_oversize_all
PASS ep0_oversize_all: all 6 commands STALL on wLength=128

$ ./fx3_cmd -F ../SDDC_FX3/SDDC_FX3.img test_health_recovery
# test_health_recovery: issuing HANGFX3(5000 ms)
#   expected: host libusb times out at 1000 ms, firmware watchdog
#   fires at ~2 s, device re-enumerates to bootloader PID 0x00F3
# HANGFX3 returned TIMEOUT as expected; waiting for watchdog reset...
# device found at bootloader PID — health watchdog fired correctly
firmware uploaded — device ready at PID 0x00F1
PASS test_health_recovery: HANGFX3 -> watchdog reset -> bootloader -> firmware re-uploaded -> device alive (hwconfig=0x04 fw=2.2)

$ for i in $(seq 1 10); do ./fx3_cmd watchdog_cap_restart; done
PASS watchdog_cap_restart: 16384 bytes after cap restart   (×10/10)

$ ./fx3_cmd soak 1 25
[1-hour soak] PASS
```

End-to-end proof: `HANGFX3` wedged the EP0 handler → host saw `LIBUSB_ERROR_TIMEOUT` at 1 s → firmware watchdog fired within window → `CyU3PDeviceReset` dropped USB → device re-enumerated to bootloader → firmware re-uploaded → normal operation resumed.  The exact failure mode that required manual USB power-cycle on PR #93's branch now self-recovers in ~4 s.

## Two issues surfaced by validation, both fixed in this PR

1. **Missed EXIT hook on early return** (commit `489411b`).  USBHandler.c has an early `return CyTrue` on the EP0 wLength-overflow check (line 189) that bypassed the bottom-of-function EXIT hook.  Result: any oversized control transfer left `in_progress` stuck, watchdog fired an unprovoked `CyU3PDeviceReset` ~2 seconds later.  Found by the first soak when `ep0_overflow`/`ep0_oversize_all` scenarios ran early.  Audit confirms no other early returns exist in the callback.

2. **Bistable 50/50 race in `watchdog_cap_restart`** (commit `5669e4d`).  Same shape as the `wedge_recovery` race fixed in PR #109 — unprimed `bulk_read_some` after `STARTFX3` at 64 MS/s loses the DMA-fill race; xHCI EP1 enters error state.  Standalone: 5/10 PASS, perfect alternation.  Migrated to `primed_start_and_read_retry`.  Standalone after fix: 10/10 PASS.

The firmware itself is unchanged by fix (2) — the test was the outlier among streaming-recovery scenarios.

## Timeout choice

`EP0_HANDLER_TIMEOUT_MS = 2000`.  Well above any legitimate handler (longest observed ~5 ms incl. 1 ms `ThreadSleep` in STOPFX3 soft-stop).  One second after host-side libusb timeout at `CTRL_TIMEOUT_MS = 1000`, so host has already given up before firmware resets.

## Cascade status (per `PLAN_RECOVERY.md` §4)

| Level | Status |
|---|---|
| 1 — Streaming wedge (DMA reset + GpifSMStart) | Implemented in existing `RunApplication.c` watchdog.  **Migration into `health_recover(WEDGED_STREAMING)` deferred to PR N**. |
| 2 — EP0 stall + flush | Not implemented. |
| 3 — Application restart | Not implemented. |
| **4 — `CyU3PDeviceReset(CyFalse)`** | **Implemented in this PR for `HEALTH_WEDGED_EP0`**. |
| 5 — FX3 HWDT | Not implemented (PR 3). |

## Gating

- [x] Firmware + host build clean (no warnings).
- [x] `test_health_recovery` PASSes end-to-end on reference hardware.
- [x] `ep0_overflow` and `ep0_oversize_all` PASS (regression cover for fix 1).
- [x] `watchdog_cap_restart` 10/10 PASSes standalone (regression cover for fix 2).
- [x] **1-hour soak PASSes on reference hardware.**
- [x] CI: build jobs green.

## Future PRs

- PR 3 — Level 5 HWDT backstop (`CyU3PSysWatchDogConfigure` + periodic pet from main loop).
- PR N (deferred) — Migrate existing streaming watchdog into `health_recover(WEDGED_STREAMING)`.  Bit-identical refactor.

Ready for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_