### PR TITLE
test(soak): add five fw_test.sh scenarios to rotation + refresh README robustness section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ handlers.
 | `health_evaluate()` | Pure function called periodically from the main loop.  Examines accumulated state and returns a structured `health_status_t`.  Does not take action. |
 | `health_recover(status)` | Called when evaluation reports unhealthy.  Picks and applies a remedy from the cascade based on the failure reason. |
 
+Plus a fourth, narrowly-scoped function used by the FX3 hardware
+watchdog (Level 5):
+
+| Function | Role |
+|---|---|
+| `health_main_heartbeat()` | Bumped once per main-loop iteration.  The HWDT clear-timer callback (KB223337 pattern, set up in `health_init()`) only pets the watchdog when the heartbeat counter has advanced since its last check — so main-thread death is what fires Level 5, not just any failure in the timer subsystem. |
+
 Adding a new failure-mode detection means adding a new event type and
 a new evaluation branch — not writing a new watchdog.
 
@@ -139,8 +146,8 @@ a new evaluation branch — not writing a new watchdog.
 | 1 | Soft-stop FW_TRG + `DmaMultiChannelReset` + `GpifSMStart` | Streaming wedge | ~300 ms | **Implemented** (existing watchdog in `RunApplication.c`; pending migration into `health_recover()` per `PLAN_RECOVERY.md` §5 PR N) |
 | 2 | EP0 stall+unstall + `FlushEp` on EP1 | EP0 stuck state | ~10 ms | **Not implemented yet** |
 | 3 | `StopApplication` + `StartApplication` | Application-level state corruption | ~100 ms | **Not implemented yet** |
-| 4 | `CyU3PDeviceReset(CyFalse)` | Anything else / catastrophic | full re-enumeration | **Implemented** in `health_recover(HEALTH_WEDGED_EP0)` for vendor-handler hangs (#104, #105) |
-| 5 | FX3 hardware watchdog timer (`CyU3PSysWatchDogConfigure` + periodic pet) | Levels 1–4 themselves wedged (i.e. main thread itself dead) | up to 10 s | **Implemented** in `health_init()` + `health_pet()` (every 100 ms from main-loop iterations); fires only if main thread stops calling pet for >10 s |
+| 4 | `CyU3PDeviceReset(CyFalse)` | Vendor-handler hang (EP0 thread deadlocked in an SDK call) | full re-enumeration (~1-2 s) | **Implemented** in `health_recover(HEALTH_WEDGED_EP0)` (#104, #105).  Validated end-to-end by `test_health_recovery` (HANGFX3). |
+| 5 | FX3 hardware watchdog timer (`CyU3PSysWatchDogConfigure`, KB223337 pattern) | Main-thread death or ThreadX scheduler/timer death — anything that prevents the heartbeat from advancing | ~5 s | **Implemented** in `health_init()` (5 s WD period) + a ThreadX timer that fires every 3 s.  The timer callback pets the WD only when `glMainHeartbeat` has advanced; a frozen heartbeat causes the WD to fire and hard-reset the device.  Validated end-to-end by `test_main_recovery` (HANGMAIN). |
 
 ### What's covered today
 
@@ -148,41 +155,63 @@ a new evaluation branch — not writing a new watchdog.
   drain, GPIF state machine in `TH0_WAIT`/`TH1_WAIT`/`TH0_RD` for
   >300 ms.  The existing watchdog in `SDDC_FX3/RunApplication.c`
   detects and recovers; observed reliable across `wedge_recovery`
-  scenarios in `fw_test.sh` and `soak_test.sh`.
+  scenarios in `fw_test.sh` and the soak rotation.
 - **EP0 vendor-handler hangs** — a vendor request callback wedged
   inside an SDK call for >2 s.  `health_evaluate()` detects via the
   EP0 enter/exit timestamp; `health_recover(HEALTH_WEDGED_EP0)` fires
-  `CyU3PDeviceReset(CyFalse)` (Level 4).  Validated end-to-end by the
-  `test_health_recovery` host scenario which uses the firmware-side
+  `CyU3PDeviceReset(CyFalse)` (Level 4).  Validated by the
+  `test_health_recovery` host scenario, which uses the firmware-side
   `HANGFX3` test command to trigger the failure deterministically.
-- **Catastrophic main-thread hang** — if the main thread itself stops
-  calling `health_pet()` for >10 s, the FX3 hardware watchdog fires
-  and resets the device (Level 5).  Pure defense in depth; covers any
-  failure mode in which Levels 1-4 (which depend on the main thread
-  to fire) become unreachable.
+- **Catastrophic main-thread death** — when the main thread stops
+  bumping `glMainHeartbeat` (deadlock, infinite loop, stack overflow,
+  ThreadX scheduler failure), the WD-clear timer callback in
+  `health.c` notices the stale counter and stops petting the FX3
+  HWDT.  The watchdog fires within ~5 s and hard-resets the device
+  (firmware re-uploaded by the host on next attach).  Validated by
+  the `test_main_recovery` host scenario, which uses the firmware-side
+  `HANGMAIN` test command to trigger the failure deterministically.
+
+### Test commands for the recovery layers
+
+| Command | Layer | What it does |
+|---|---|---|
+| `HANGFX3` (`0xCE`) | Level 4 | Test-only vendor command; sleeps `wValue` ms in the EP0 handler context.  Used by `test_health_recovery` to deterministically trip the EP0 watchdog. |
+| `HANGMAIN` (`0xCF`) | Level 5 | Test-only vendor command; sets a flag so the main thread enters an infinite spin on its next iteration.  Used by `test_main_recovery` to deterministically trip the FX3 HWDT. |
+
+Both are safe in production firmware — invoking either eventually
+self-recovers via the respective watchdog layer.
 
 ### What's not covered yet — known gaps
 
-- **EP0 / vendor-handler hangs** (issue #104, #105).  When a vendor
-  handler such as STOPFX3 hangs inside an FX3 SDK call, EP0 stops
-  responding while USB enumeration remains alive.  Today's watchdog
-  cannot fire (its gating conditions are streaming-specific) and
-  there is no other recovery layer below it; manual USB power-cycle
-  is the only recourse.  Target: cascade level 4 in PR 2.
-
 - **`gpif_soft_stop` 1 ms timing window** (issue #106).  An
-  intermittent (~10% per cycle) where the firmware's 1 ms wait after
-  `FW_TRG` deassertion is insufficient for the SM to reach IDLE,
-  causing a force-stop fallback.  Independent of the recovery
-  architecture; tracked separately.
+  intermittent (originally observed ~10% per cycle) where the
+  firmware's 1 ms wait after `FW_TRG` deassertion is insufficient
+  for the SM to reach IDLE, causing a force-stop fallback.
+  Independent of the recovery architecture; tracked separately.
+  Now in the soak rotation, so future runs will provide empirical
+  evidence on whether PR #112's scheduling changes affected the rate.
+
+- `boot_count` (GETSTATS byte [20..23]) — increments once per
+  firmware `health_init()`.  Use to detect mid-test device resets:
+  snapshot before, compare after.  Mismatch means the device reset
+  (cause indistinguishable without further state, but presence of
+  reset is unambiguous).
 
 ### Soak status
 
-Latest 1-hour soak on current `main`: 2099 cycles, 1 transient
-`rapid_start_stop` failure (self-recovered, 0.05% per-cycle rate),
-zero unrecoverable wedges, health checks 2099/2099.  Specific failure
-modes covered by `health.c` cascade levels will be retested after each
-level lands.
+Latest 2-hour soak on the PR #112 firmware (commit `0fcfae8`, seed
+26): 3368 cycles, 1 transient failure (`test_health_recovery`, #113 —
+unrelated to the recovery cascade itself; the deterministic version
+passes 100%), health checks 3368/3368 passed.  Recovery cascade
+exercised:
+
+| Level | Soak scenario | Runs | Pass | Fail |
+|---|---|---|---|---|
+| 1 | `wedge_recovery` | 211 | 211 | 0 |
+| 4 | `test_health_recovery` | 55 | 54 | 1 |
+| 5 | `test_main_recovery` | 58 | 58 | 0 |
+
+Result: 0.03% per-cycle failure rate, no unrecoverable wedges.
 
 ## Docker — ka9q-radio Compatibility Testing
 

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -4493,6 +4493,19 @@ static int soak_main(libusb_device_handle **h_inout, int argc, char **argv)
         {"debug_cmd_stream",    do_test_debug_cmd_while_stream,3, 0, 0, 0},
         {"readinfodebug_flood", do_test_readinfodebug_flood,  3, 0, 0, 0},
         {"data_sanity",         do_test_data_sanity,          2, 0, 0, 0},
+        /* fw_test.sh scenarios that were never added to the soak rotation.
+         * Audit traced these to a mix of historical oversight (older
+         * tests) and a stacked-PR mess that lost their wiring (the two
+         * gpif/stop tests).  All are stress-worthy and have no known
+         * isolation concerns.  Weight 3 each → ~12-15 invocations / 1h
+         * soak.  Note: gpio_extremes is *intentionally* not here —
+         * commit 1670384 documents a side-effect leak that contaminates
+         * subsequent scenarios, so it stays fw_test.sh-only. */
+        {"gpif_soft_stop",      do_test_gpif_soft_stop,       3, 0, 0, 0},
+        {"stop_under_backpressure", do_test_stop_under_backpressure, 3, 0, 0, 0},
+        {"hw_smoke",            do_test_hw_smoke,             3, 0, 0, 0},
+        {"stop_gpif_state",     do_test_stop_gpif_state,      3, 0, 0, 0},
+        {"vendor_rqt_wrap",     do_test_vendor_rqt_wrap,      3, 0, 0, 0},
         /* Recovery round-trip tests — slow (~15 s each including reset
          * and firmware re-upload) but valuable because they exercise
          * the actual Level 4 / Level 5 reset paths under random


### PR DESCRIPTION
## Summary

Two small, related changes after PR #112's recovery cascade work landed:

1. **Five `fw_test.sh` scenarios added to the soak rotation.**  Audit of `fw_test.sh` vs the soak's `scenarios[]` array found 12 tests in fw_test.sh that weren't exercised by the soak.  Six are correctly out (pure-read smokes or known side-effect concerns).  Five are stress-worthy with no isolation concerns — added at weight 3 each, ~12-15 invocations per 1-hour soak.

2. **README.md "Firmware Robustness" section refreshed** to match PR #112's actual implementation.  The section had three concrete factual errors before this PR (described below).

Net diff: +63 / -27 across two files (`tests/fx3_cmd.c`, `README.md`).  No firmware changes.

## Soak rotation additions

| Scenario | Reason it was missing |
|---|---|
| `gpif_soft_stop` | Originally added in `8e00ab8`, got tangled in a stacked-PR mess, restored to `fw_test.sh` by PR #108 but I missed adding it to the soak rotation when wiring the other dispatchers. |
| `stop_under_backpressure` | Same — paired with `gpif_soft_stop` in the same stacked-PR loss. |
| `hw_smoke` | Older test; no documented reason for exclusion. |
| `stop_gpif_state` | Older test; no documented reason for exclusion. |
| `vendor_rqt_wrap` | Older test; no documented reason for exclusion. |

Intentionally **not** added: `gpio_extremes` (commit `1670384` documents a GPIO-leak side effect that contaminates subsequent scenarios — would need isolation work first); `stats`, `stats_pll`, `debug_poll`, `stack_check` (pure-read smokes — soak's between-scenario health check already issues `TESTFX3` and `GETSTATS` constantly, would be redundant); `stats_pib` (overlaps with `pib_overflow` already in rotation).

## README refresh

Three concrete corrections + several additions to the "Firmware Robustness" section:

| Was | Now |
|---|---|
| Level 5 row described "every 100 ms from main-loop iterations; fires only if main thread stops calling pet for >10 s" (the *broken* approach we bisected away from in PR #112) | Level 5 row describes KB223337 timer (3 s pet interval), 5 s WD period, heartbeat-gated pet so main-thread death is what fires it |
| "Known gaps" listed EP0/vendor-handler hangs (#104, #105) as not covered | Removed — Level 4 has been live since PR #110 |
| Soak status cited the old 2099-cycle PR #110 baseline | Refreshed to PR #112's 2-hour, 3368-cycle soak, with the cascade-levels-exercised table |

Additions:
- `health_main_heartbeat()` documented in the interface table (4th function added in PR #112).
- `HANGFX3` / `HANGMAIN` test commands documented in a new table — they're real vendor commands now, safe in production because the watchdogs auto-recover.
- `boot_count` GETSTATS field mentioned in "Known gaps" with semantics.
- Level-4 cascade row gains "Validated by `test_health_recovery` (HANGFX3)"; Level 5 gains "Validated by `test_main_recovery` (HANGMAIN)".

## Hardware validation

Two independent 1-hour soak runs on the branch firmware (same as `main` plus this PR's changes — no firmware change, only host-side additions):

| Soak | Seed | Cycles | Pass | Fail | Health checks | Notes |
|---|---|---|---|---|---|---|
| A | 25 | 1717 | 1716 | 1 | 1717/1717 | Single failure: `rapid_start_stop` at the very start (cold-start race; see #119) |
| B | 1778748654 | 2087 | 2086 | 1 | 2087/2087 | Single failure: `wedge_recovery` at the very start (same cold-start pattern; see #119) |

Combined per-cycle failure rate: ~0.05%.  Same low rate as PR #112's baseline soak.  No regression from adding the new scenarios to the rotation.

**The five new scenarios' per-soak pass counts:**

| Scenario | Soak A | Soak B | Total |
|---|---|---|---|
| `gpif_soft_stop` | 27 / 27 | 33 / 33 | **60 / 60** |
| `stop_under_backpressure` | 19 / 19 | 22 / 22 | 41 / 41 |
| `hw_smoke` | 20 / 20 | 24 / 24 | 44 / 44 |
| `stop_gpif_state` | 22 / 22 | 25 / 25 | 47 / 47 |
| `vendor_rqt_wrap` | 20 / 20 | 27 / 27 | 47 / 47 |

## Observations surfaced by this soak data

1. **`gpif_soft_stop` is no longer observable as failing.**  Original observation in #106 was ~10% per-cycle.  60 invocations across two seeds = expected ~6 failures.  Got zero.  Closed #106 as not-currently-observable (mirror of #80 treatment).  Plausible cause: PR #112's ThreadX timer shifted scheduling cadence enough to land the 1 ms wait reliably.

2. **A "cold-start" pattern surfaced.**  Both soaks had exactly one failure, both at the very start of the run, both in streaming-stress scenarios returning 0 bytes with `pib_arg=0x1005` (thread-not-ready).  N=2 with consistent placement is suspicious; filed #119 to track.  Low rate, not gating.

## Closes / refs

- Refs #106 (closed as not_planned based on this PR's evidence).
- Refs #119 (newly filed; this PR is the soak surface that revealed it).
- Refs #114 (separate doc audit of six other recovery-referencing docs; not part of this PR).

## Out of scope (deferred)

- Migrating `rapid_start_stop` from `bulk_read_some` to `primed_start_and_read_retry` (would close one race surface but is its own follow-up; tracked under #119 if it matters).
- Migration of the streaming watchdog into `health_recover()` (deferred per `PLAN_RECOVERY.md` §5 PR N).
- The doc audit of `docs/gpif-and-recovery.md`, `docs/wedge_detection.md`, `docs/architecture.md`, `docs/diagnostics_side_channel.md`, `SDDC_FX3/docs/debugging.md`, `tests/README.md` (tracked in #114).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roa2FJjCcnnRvFEkVzcfZB)_