### PR TITLE
docs: GitHub Pages site for rx888-firmware (plan)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Jekyll site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/PLAN_GH_PAGES.md
+++ b/PLAN_GH_PAGES.md
@@ -1,0 +1,202 @@
+# PLAN — GitHub Pages site for rx888-firmware
+
+## Goal
+
+Stand up a public project page at
+`https://ringof.github.io/rx888-firmware/` that serves as the developer-
+facing front door for the firmware, in the same vein as the project
+pages used by `rx888-tools` and `ka9q-radio`.
+
+The site must satisfy three audiences:
+
+1. **End users / integrators** evaluating whether to use this firmware
+   on an RX888mk2 — quick overview, compatibility, where to get a
+   release.
+2. **Host-application developers** writing software that drives the
+   firmware — needs a complete, accurate USB vendor-command reference,
+   GPIO map, argument list, and behavior notes.
+3. **Firmware contributors** — needs links into the architecture and
+   recovery docs already present in `docs/`.
+
+## Non-goals
+
+- No backend / no JS app. Static content only.
+- No duplication of `README.md` content. The site links to or includes
+  the canonical document; it does not maintain a second copy that can
+  drift.
+- No new vendor commands, no firmware behavior changes. This plan is
+  documentation-and-site-config only.
+
+## Hosting decision
+
+**Use GitHub Pages with the GitHub Actions deployment source**
+(`actions/deploy-pages`), built from the existing `docs/` directory
+plus a small set of new top-level site files. Build with Jekyll using
+the `just-the-docs` remote theme.
+
+Why this combination:
+
+- **GitHub Actions source (not "deploy from /docs branch")** — gives us
+  a single deploy workflow we can extend later (e.g., to auto-generate
+  the API reference page from `protocol.h`). Keeps `docs/` as a
+  filesystem directory that contributors edit directly; CI handles
+  publishing.
+- **Jekyll** — natively supported by GitHub Pages, no Node toolchain
+  to maintain, renders the existing `.md` files in `docs/` with no
+  conversion.
+- **just-the-docs theme** — purpose-built for technical/API
+  documentation: persistent sidebar, search, anchor-linkable headings,
+  and good rendering of reference tables (which we'll need heavily for
+  the vendor-command table). Matches the visual idiom used by
+  comparable SDR project pages.
+
+Alternatives considered and rejected:
+
+- **Render `README.md` only via the default Pages theme.** Insufficient
+  — the README is already long and the API reference would dominate
+  it. We need multiple pages with navigation.
+- **mkdocs / Sphinx / Docusaurus.** Add a build toolchain (Python or
+  Node) for marginal benefit over Jekyll. Not justified for a site of
+  this size.
+- **Hand-rolled static HTML.** Rejected on maintenance grounds.
+
+## Site structure
+
+All site sources live in `docs/` (the directory already exists and
+already contains the canonical reference docs). New files marked
+`(NEW)`; existing files marked `(EXISTING)`:
+
+```
+docs/
+  _config.yml                 (NEW)  Jekyll site config, theme, nav order
+  index.md                    (NEW)  Landing page — overview, badges, quick links
+  api.md                      (NEW)  USB vendor-command reference (primary deliverable)
+  building.md                 (NEW)  Pulled from README "Building" section, links back
+  compatibility.md            (NEW)  Host-app compatibility matrix (ka9q-radio, rx888_tools, ExtIO)
+  architecture.md             (EXISTING — front-matter added)
+  gpif-and-recovery.md        (EXISTING — front-matter added)
+  diagnostics_side_channel.md (EXISTING — front-matter added)
+  wedge_detection.md          (EXISTING — front-matter added)
+  vendor-protocol-plan.md     (EXISTING — front-matter added; marked "design notes")
+  ka9q-compat-audit.md        (EXISTING — front-matter added; marked "design notes")
+  LICENSE_ANALYSIS.md         (EXISTING — front-matter added; marked "reference")
+  assets/
+    favicon.png               (NEW, optional)
+```
+
+The eight existing `.md` files in `docs/` need a small Jekyll
+front-matter block prepended (title, nav_order, parent group) so they
+slot into the sidebar correctly. Their body content is not modified.
+
+## Primary content: `docs/api.md`
+
+This is the deliverable that distinguishes this site from a vanilla
+README render. It must contain, verified against `SDDC_FX3/protocol.h`:
+
+1. **USB device identity** — VID/PID for both bootloader and programmed
+   states (`04b4:00f3` and `04b4:00f1`, verified from `USBDescriptor.c`).
+2. **Vendor command table** — one row per `enum FX3Command` entry in
+   `protocol.h`. Columns: name, bRequest, direction (IN/OUT), wValue
+   semantics, wIndex semantics, data-stage description, error
+   conditions, notes. Source of truth is `protocol.h` + the
+   handler implementations in `USBHandler.c`.
+3. **GPIO control bits** — the `OUTXIO*` / `enum GPIOPin` map from
+   `protocol.h`, with the physical-function annotations (ATT_LE,
+   SHDWN, DITH, etc.) already in the header.
+4. **`SETARGFX3` argument list** — the `enum ArgumentList` from
+   `protocol.h` (`DAT31_ATT`, `AD8370_VGA`, `WDG_MAX_RECOV`), with
+   value ranges and defaults.
+5. **`GETSTATS` byte layout** — the diagnostic-counter byte offsets.
+   Source: the `GETSTATS` handler in `USBHandler.c` and the
+   `boot_count` reference in the README. Must be verified by reading
+   the handler, not transcribed from memory.
+6. **Streaming pipeline summary** — endpoint number, transfer type,
+   packet size, expected throughput. Source: `USBDescriptor.c`.
+7. **Test-only commands** (`HANGFX3`, `HANGMAIN`) — explicitly marked
+   test-only; documented because they are useful to host-side
+   integrators writing recovery tests, but flagged as not for
+   production use.
+8. **Versioning** — `FIRMWARE_VER_MAJOR`/`MINOR` from `protocol.h`,
+   plus how to read it back via `TESTFX3`.
+
+**Verification discipline:** every row in `api.md` cites a source
+file:line. No claim about command behavior goes into the page without
+being checked against the C source. If a behavior is ambiguous in the
+source, the page says so rather than guessing.
+
+## CI workflow
+
+Add `.github/workflows/pages.yml`:
+
+- Triggers: `push` to default branch on paths `docs/**`, `README.md`,
+  `.github/workflows/pages.yml`; plus `workflow_dispatch`.
+- Single job using the standard `actions/configure-pages`,
+  `actions/jekyll-build-pages`, `actions/upload-pages-artifact`,
+  `actions/deploy-pages` sequence.
+- Permissions block: `pages: write`, `id-token: write`, `contents: read`.
+- Concurrency group `pages` so overlapping pushes don't race.
+
+The workflow does **not** modify `build.yml` or `release.yml`.
+
+## Repository settings change (manual, one-time)
+
+After the workflow lands and the first run is green, the repo admin
+must flip **Settings → Pages → Source** from "Deploy from a branch"
+(default) to **"GitHub Actions"**. This step requires the repo admin
+and cannot be automated from the PR; it will be called out in the PR
+description.
+
+## Optional follow-up (not in this PR)
+
+- **Auto-generate `api.md` from `protocol.h`** via a small script run
+  in the pages workflow. Worth doing once the hand-written page is
+  stable and we know exactly what shape we want; premature now.
+- **Link the site from `README.md`** at the top, once the site is
+  actually published and the URL is confirmed live.
+- **Custom domain.** Out of scope.
+
+## Work breakdown
+
+1. Add `docs/_config.yml` with `just-the-docs` remote theme + nav
+   configuration.
+2. Add `docs/index.md` landing page.
+3. Add `docs/api.md` — verified against `protocol.h`, `USBHandler.c`,
+   `USBDescriptor.c`.
+4. Add `docs/building.md` and `docs/compatibility.md` (short pages
+   linking to README sections and to host-app repos).
+5. Prepend Jekyll front-matter to the 7 existing `docs/*.md` files
+   (architecture, gpif-and-recovery, diagnostics_side_channel,
+   wedge_detection, vendor-protocol-plan, ka9q-compat-audit,
+   LICENSE_ANALYSIS). No body edits.
+6. Add `.github/workflows/pages.yml`.
+7. Local sanity check: render with `bundle exec jekyll serve` is not
+   required (CI is authoritative), but `jekyll-build-pages` will fail
+   loudly on bad front-matter; we'll rely on the first workflow run
+   for validation.
+8. Open PR as draft. Call out the manual Pages-source toggle in the PR
+   description.
+
+## Validation
+
+After merge and the manual Pages-source toggle:
+
+- `https://ringof.github.io/rx888-firmware/` loads and shows the
+  landing page.
+- Sidebar lists API, Building, Compatibility, Architecture, GPIF &
+  Recovery, Diagnostics, Wedge Detection, License Analysis.
+- `https://ringof.github.io/rx888-firmware/api/` renders the vendor-
+  command table with anchor-linkable command names
+  (e.g. `…/api/#startfx3`).
+- Spot-check three command rows against `protocol.h` and
+  `USBHandler.c`.
+
+## Regression
+
+- `make -C SDDC_FX3 clean all` still produces `SDDC_FX3.img` (this PR
+  changes no firmware sources).
+- `build.yml` and `release.yml` runs are unaffected (this PR adds a
+  new workflow on disjoint paths/triggers; existing workflows trigger
+  on `push`/`pull_request` and `push:tags` respectively).
+- The 7 existing `docs/*.md` files render unchanged on GitHub's
+  in-repo Markdown preview (Jekyll front-matter is fenced YAML at the
+  top, which GitHub's renderer hides).

--- a/docs/LICENSE_ANALYSIS.md
+++ b/docs/LICENSE_ANALYSIS.md
@@ -1,3 +1,9 @@
+---
+title: License analysis
+nav_order: 11
+permalink: /LICENSE_ANALYSIS/
+---
+
 # License Analysis
 
 ## 1. Current License Landscape

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,36 @@
+title: rx888-firmware
+description: >-
+  Cypress FX3 USB controller firmware for the RX888 mk2 direct-sampling SDR
+  receiver. HF reception (0–32 MHz) via the on-board LTC2208 ADC.
+url: https://ringof.github.io
+baseurl: /rx888-firmware
+
+remote_theme: just-the-docs/just-the-docs
+
+permalink: pretty
+
+color_scheme: dark
+
+search_enabled: true
+search:
+  heading_level: 3
+  previews: 2
+  preview_words_before: 3
+  preview_words_after: 3
+
+aux_links:
+  "GitHub":
+    - "https://github.com/ringof/rx888-firmware"
+  "Releases":
+    - "https://github.com/ringof/rx888-firmware/releases"
+aux_links_new_tab: true
+
+heading_anchors: true
+
+footer_content: >-
+  MIT-licensed firmware. The Cypress FX3 SDK is covered by the Cypress Software
+  License Agreement.
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,499 @@
+---
+title: USB API reference
+nav_order: 2
+permalink: /api/
+---
+
+# USB API reference
+{: .no_toc }
+
+Complete USB vendor-command protocol exposed by the rx888-firmware FX3
+image.  Every claim on this page cites a source file and line in the
+firmware tree; if behavior differs between this page and the source, the
+source is authoritative — please open an issue.
+
+Reference firmware version: **2.2**
+(`FIRMWARE_VER_MAJOR=2`, `FIRMWARE_VER_MINOR=2` —
+`SDDC_FX3/protocol.h:10-11`).
+
+1. TOC
+{:toc}
+
+---
+
+## USB device identity
+
+The FX3 enumerates with two different PIDs depending on whether the
+firmware has been uploaded to RAM:
+
+| State            | VID    | PID    | Product string | Notes |
+|------------------|--------|--------|----------------|-------|
+| Bootloader (cold-boot, no firmware) | `04b4` | `00f3` | (FX3 BootROM)  | Host uses this PID to upload the firmware image with the standard FX3 BootROM protocol; see [Building]({{ '/building/' | relative_url }}). PID value from the `rx888_tools` udev rule referenced in `README.md`. |
+| Programmed (firmware running)       | `04b4` | `00f1` | `RX888mk2`     | VID/PID from `SDDC_FX3/USBDescriptor.c:27-28` (SS) and `:46-47` (HS); product string from `SDDC_FX3/USBDescriptor.c:218-224`. |
+
+The serial number string is generated at boot from the FX3 die ID
+(`SDDC_FX3/USBDescriptor.c:274-294`) — 16 hex characters, stable for a
+given device.
+
+## USB endpoints
+
+The firmware exposes a single vendor-specific interface with one bulk IN
+endpoint plus EP0 for control transfers.  Endpoint address and packet
+sizes come from `SDDC_FX3/USBDescriptor.c` and `SDDC_FX3/Application.h`.
+
+| Speed        | Endpoint           | Type            | Max packet | Burst | Source |
+|--------------|--------------------|-----------------|------------|-------|--------|
+| SuperSpeed   | `0x81` (EP1 IN)    | Bulk, IQ stream | 1024 B     | 16    | `USBDescriptor.c:118-131`, `Application.h:64-65` |
+| High Speed   | `0x81` (EP1 IN)    | Bulk            | 512 B      | n/a   | `USBDescriptor.c:158-164` |
+| Full Speed   | `0x81` (EP1 IN)    | Bulk            | 64 B       | n/a   | `USBDescriptor.c:191-197` |
+| Any          | EP0                | Control         | 512 B (SS) / 64 B (HS,FS) | — | `USBDescriptor.c:26`, `:45` |
+
+EP0 vendor requests are limited to **64 bytes of data-phase payload**
+(`CYFX_SDRAPP_MAX_EP0LEN`, `SDDC_FX3/USBHandler.c:47`).  Requests with
+`wLength > 64` are rejected with a STALL on EP0 before any data phase
+runs (`USBHandler.c:187-193`).
+
+The streaming IQ pipeline uses 4 DMA buffers of 16 KB each
+(`Application.h:41-44`), assembled in a multi-channel ping-pong from
+two PIB sockets to USB socket 1.  The IQ data is **16-bit signed,
+little-endian, single-channel** (the LTC2208 ADC output sign-extended
+to 16 bits; randomization can be enabled via the `RAND` GPIO bit — see
+[`GPIOFX3`](#gpiofx3)).
+
+## Vendor command summary
+
+All vendor commands target `bmRequestType` with `Type=Vendor`,
+`Recipient=Device`.  Command code is `bRequest`.  Source of truth:
+`enum FX3Command` in `SDDC_FX3/protocol.h:14-41` and the dispatch in
+`SDDC_FX3/USBHandler.c:195-528`.
+
+| `bRequest` | Name              | Dir   | Data length | Brief                                          |
+|------------|-------------------|-------|-------------|------------------------------------------------|
+| `0xAA`     | [`STARTFX3`](#startfx3) | OUT | 0 | Start GPIF engine; begin IQ stream on EP1.    |
+| `0xAB`     | [`STOPFX3`](#stopfx3)   | OUT | 0 | Stop GPIF engine; drain DMA.                  |
+| `0xAC`     | [`TESTFX3`](#testfx3)   | IN  | 4 | Read hardware/firmware version + counters.    |
+| `0xAD`     | [`GPIOFX3`](#gpiofx3)   | OUT | 4 | Set GPIO control word.                        |
+| `0xAE`     | [`I2CWFX3`](#i2cwfx3)   | OUT | n | Write `wLength` bytes to I2C address `wIndex` at register `wValue`. |
+| `0xAF`     | [`I2CRFX3`](#i2crfx3)   | IN  | n | Read `wLength` bytes from I2C address `wIndex` at register `wValue`. |
+| `0xB1`     | [`RESETFX3`](#resetfx3) | OUT | 0 | Reset FX3 to BootROM (PID `00f3`).            |
+| `0xB2`     | [`STARTADC`](#startadc) | OUT | 4 | Program Si5351 to ADC clock frequency (Hz).   |
+| `0xB3`     | [`GETSTATS`](#getstats) | IN  | ≤64 | Diagnostic counters (see byte layout below). |
+| `0xB6`     | [`SETARGFX3`](#setargfx3) | OUT | n | Set parameter `wIndex` to value `wValue`.  |
+| `0xBA`     | [`READINFODEBUG`](#readinfodebug) | IN/OUT | ≤64 | Debug console RX (wValue=ASCII) / TX. |
+| `0xCE`     | [`HANGFX3`](#hangfx3)   | —   | 0 | **Test-only.** Sleep `wValue` ms in EP0 handler. |
+| `0xCF`     | [`HANGMAIN`](#hangmain) | —   | 0 | **Test-only.** Arm main-thread infinite spin. |
+
+> **Direction is from the host's perspective.** `OUT` = data flows
+> host → device; `IN` = device → host; `—` = no data phase (status only).
+
+---
+
+## Command details
+
+### STARTFX3
+
+Source: `SDDC_FX3/USBHandler.c:332-393`.
+
+Starts the GPIF state machine and the PIB → USB DMA pipeline.  Once
+`STARTFX3` returns success, the device begins producing IQ samples on
+EP1 IN (`0x81`).
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xAA`              |
+| `bmRequestType` | `0x40` (OUT, Vendor, Device) |
+| `wValue`      | 0 (ignored)         |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 0                   |
+
+**Behavior:**
+
+1. Disables USB Link Power Management for the duration of the stream
+   (`USBHandler.c:333`).
+2. **Preflight:** verifies the Si5351 ADC clock is running and locked
+   via `GpifPreflightCheck()` (`USBHandler.c:343-349`).  If not, the
+   status phase is STALLed.  Sequence requirement: host must call
+   [`STARTADC`](#startadc) (with a non-zero frequency) **before**
+   `STARTFX3`.
+3. Force-stops any running GPIF SM, resets the multi-channel DMA, and
+   flushes the consumer endpoint (`USBHandler.c:356-362`).
+4. Reloads the GPIF waveform and re-arms the SM.
+
+**Failure mode:** any internal failure (preflight, DMA setup, or GPIF
+load) results in a STALL on the status phase
+(`USBHandler.c:343-348, :388`).  Streaming will not start.  No retry
+is performed inside the firmware — the host must STALL-clear,
+diagnose, and re-issue.
+
+### STOPFX3
+
+Source: `SDDC_FX3/USBHandler.c:395-424`.
+
+Stops the GPIF state machine cleanly and drains the DMA pipeline.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xAB`              |
+| `bmRequestType` | `0x40`            |
+| `wValue`      | 0 (ignored)         |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 0                   |
+
+**Behavior:** deasserts the `FW_TRG` input, sleeps ~1 ms for the SM to
+quiesce, disables GPIF (soft if SM reached IDLE, force otherwise),
+resets the DMA channel, and flushes the consumer endpoint
+(`USBHandler.c:404-418`).  Re-enables LPM (`:396`).
+
+**Always succeeds from the host's perspective** — the firmware does
+not STALL even on an unclean stop; the diagnostic counter `glCounter[1]`
+is bumped instead.  Verify cleanly via [`GETSTATS`](#getstats) byte
+[8] (GPIF SM state == `1` IDLE).
+
+### TESTFX3
+
+Source: `SDDC_FX3/USBHandler.c:433-442`.
+
+Reads back the hardware-config byte, firmware version, and vendor
+request counter.  Side effect: setting `wValue=1` enables debug-flag
+output to the host-side debug console.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xAC`              |
+| `bmRequestType` | `0xC0` (IN, Vendor, Device) |
+| `wValue`      | 0 (normal) or 1 (set debug flag) |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 4                   |
+
+**Response (4 bytes):**
+
+| Byte | Field         | Source |
+|------|---------------|--------|
+| 0    | `glHWconfig`  | `RX888r2 = 0x04`, `NORADIO = 0x00` (`protocol.h:75-78`) |
+| 1    | `FIRMWARE_VER_MAJOR` | `protocol.h:10` |
+| 2    | `FIRMWARE_VER_MINOR` | `protocol.h:11` |
+| 3    | `glVendorRqtCnt`     | Wraps at 256.  Useful as a liveness probe across calls. |
+
+### GPIOFX3
+
+Source: `SDDC_FX3/USBHandler.c:197-204`, dispatched to
+`rx888r2_GpioSet()` in `SDDC_FX3/radio/rx888r2.c:17-27`.
+
+Sets the device GPIO control word in a single 32-bit OUT data phase.
+Only the bits described in the [GPIO bit map](#gpio-bit-map) below are
+acted on; other bits are ignored.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xAD`              |
+| `bmRequestType` | `0x40`            |
+| `wValue`      | 0 (ignored)         |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 4                   |
+| Data          | 32-bit little-endian control word |
+
+`GPIOFX3` is the host's primary lever for controlling LEDs, the front-
+end shutdown line, the ADC dither/randomization options, bias-tee
+power, and front-end path selection.
+
+### I2CWFX3
+
+Source: `SDDC_FX3/USBHandler.c:281-294`.
+
+Writes to a peripheral on the FX3 I2C bus.  Used by host applications
+to drive any I2C device on the RX888mk2 — Si5351 clock generator,
+R828D tuner registers, etc.
+
+| Field         | Value                                                  |
+|---------------|--------------------------------------------------------|
+| `bRequest`    | `0xAE`                                                 |
+| `bmRequestType` | `0x40`                                               |
+| `wValue`      | Slave-device register address (subaddress); passed as the I2C `regAddr` field |
+| `wIndex`      | I2C slave address shifted into the I2C controller's address register (see firmware's `I2cTransfer()`) |
+| `wLength`     | Bytes to write (≤ 64)                                 |
+| Data          | Payload                                                |
+
+The I2C controller is configured for 7-bit addresses; consult
+`SDDC_FX3/i2cmodule.c` for the exact subaddress encoding if your host
+target needs multi-byte sub-addresses.  STALLs the status phase if the
+I2C transaction returns an SDK error
+(`USBHandler.c:291`).
+
+### I2CRFX3
+
+Source: `SDDC_FX3/USBHandler.c:296-304`.
+
+Reads from a peripheral on the FX3 I2C bus.
+
+| Field         | Value                                                  |
+|---------------|--------------------------------------------------------|
+| `bRequest`    | `0xAF`                                                 |
+| `bmRequestType` | `0xC0`                                               |
+| `wValue`      | Slave-device register address (subaddress)             |
+| `wIndex`      | I2C slave address (see `I2CWFX3` note)                 |
+| `wLength`     | Bytes to read (≤ 64)                                  |
+
+Response: `wLength` bytes from the slave.  If the I2C transaction
+fails, no data is sent and the status phase is unhandled (host should
+treat as a transient error and retry).
+
+### RESETFX3
+
+Source: `SDDC_FX3/USBHandler.c:426-431`.
+
+Hard-resets the FX3.  The host-side debug message
+`"HOST RESETTING CPU"` is printed, the firmware sleeps 100 ms, then
+calls `CyU3PDeviceReset(CyFalse)`.  After this command the device
+re-enumerates as VID/PID `04b4:00f3` (BootROM); the host must re-upload
+the firmware image to restore normal operation.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xB1`              |
+| `bmRequestType` | `0x40`            |
+| `wValue`      | 0 (ignored)         |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 0                   |
+
+### STARTADC
+
+Source: `SDDC_FX3/USBHandler.c:206-253`.
+
+Programs the Si5351 ADC clock to the specified frequency in Hz.  Sent
+before `STARTFX3` to bring the LTC2208 sample clock up to the desired
+rate.
+
+| Field         | Value                                                  |
+|---------------|--------------------------------------------------------|
+| `bRequest`    | `0xB2`                                                 |
+| `bmRequestType` | `0x40`                                               |
+| `wValue`      | 0 (ignored)                                            |
+| `wIndex`      | 0 (ignored)                                            |
+| `wLength`     | 4                                                      |
+| Data          | 32-bit little-endian frequency in Hz                   |
+
+**Behavior:** if the GPIF SM is currently running, the firmware
+implicitly stops it before reprogramming the clock (changing the
+Si5351 output while the SM is running wedges the PIB)
+(`USBHandler.c:217-227`).  After programming, the firmware polls
+Si5351 PLL lock for up to 100 ms before returning
+(`USBHandler.c:240-246`).
+
+**Failure mode:** if `si5351aSetFrequencyA` returns a non-success
+status, the status phase is left unhandled and a debug message is
+emitted (`USBHandler.c:248-251`).
+
+### GETSTATS
+
+Source: `SDDC_FX3/USBHandler.c:255-279`.
+
+Reads back diagnostic counters and state.  The firmware fills a
+fixed-layout buffer up to 24 bytes total.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xB3`              |
+| `bmRequestType` | `0xC0`            |
+| `wValue`      | 0 (ignored)         |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | ≤ 64 (firmware sends 24) |
+
+**Byte layout** (little-endian for multi-byte fields):
+
+| Offset | Width | Name              | Description |
+|--------|-------|-------------------|-------------|
+| 0–3    | u32   | `glDMACount`      | DMA completion count since the most recent `STARTFX3`. Reset to 0 on `STARTFX3`/`STOPFX3`. (`USBHandler.c:375`, `:419`.) |
+| 4      | u8    | `gpifState`       | GPIF state machine state at the moment the request was serviced.  IDLE = 1.  255 means `CyU3PGpifGetSMState` failed. |
+| 5–8    | u32   | `glCounter[0]`    | Free-running counter incremented in the main loop; useful as a liveness probe. |
+| 9–10   | u16   | `glLastPibArg`    | Last argument captured from the PIB error path (see `gpif-and-recovery.md`). |
+| 11–14  | u32   | `glCounter[1]`    | Counter 1 — currently used for unclean-stop events. |
+| 15–18  | u32   | `glCounter[2]`    | Counter 2 — EP underrun count (`USBHandler.c:563`). |
+| 19     | u8    | Si5351 reg 0      | Live read of Si5351 status register (PLL lock bits).  Useful for confirming the ADC clock health without separately issuing `I2CRFX3`. |
+| 20–23  | u32   | `boot_count`      | Increments once per firmware `health_init()` call.  Use to detect mid-test resets: snapshot before, compare after; mismatch means the device reset.  (`SDDC_FX3/health.c:health_boot_count`.) |
+
+The firmware sends exactly 24 bytes via `CyU3PUsbSendEP0Data`; hosts
+should request `wLength=24` (or up to 64) and read the prefix that
+fits.
+
+### SETARGFX3
+
+Source: `SDDC_FX3/USBHandler.c:305-330`.
+
+Generic "set parameter by index" sidedoor.  `wIndex` selects which
+parameter; `wValue` is the new value.  A small EP0 data phase is sent
+but its contents are ignored — `wValue` carries the data.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xB6`              |
+| `bmRequestType` | `0x40`            |
+| `wValue`      | New parameter value |
+| `wIndex`      | Parameter selector (see below) |
+| `wLength`     | n (sent but ignored — host may send 0 or a small payload; payload bytes are discarded) |
+
+Defined parameter selectors (`enum ArgumentList` in
+`SDDC_FX3/protocol.h:80-84`):
+
+| `wIndex` | Name           | `wValue` range            | Effect | Source |
+|----------|----------------|---------------------------|--------|--------|
+| 10       | `DAT31_ATT`    | 0 – 63 (6-bit, 0.5 dB)    | Sets the DAT-31 step attenuator.  6 bits shifted to `ATT_LE`. | `rx888r2_SetAttenuator()`, `radio/rx888r2.c:78-82` |
+| 11       | `AD8370_VGA`   | 0 – 255 (raw 8-bit register) | Sets the AD8370 VGA gain register.  See AD8370 datasheet for the gain-code mapping. | `rx888r2_SetGain()`, `radio/rx888r2.c:84-89` |
+| 14       | `WDG_MAX_RECOV` | 0 (unlimited) – 255      | Caps consecutive watchdog recoveries.  Default `WDG_MAX_RECOVERY_DEFAULT = 5` (`protocol.h:86`).  After the cap, the firmware reboots instead of attempting another recovery — used by host-side tests to bound flakiness. | `protocol.h:83`, `USBHandler.c:318-322` |
+
+Unrecognized `wIndex` values are signaled by STALLing the status phase
+(`USBHandler.c:323-328`).  Recognized calls bump `glVendorRqtCnt`.
+
+> Note: protocol-numbered selectors that are absent from the table
+> (e.g. 0–9, 12–13) are **not** currently dispatched by the firmware.
+> They are reserved for future use and will STALL.
+
+### READINFODEBUG
+
+Source: `SDDC_FX3/USBHandler.c:481-520`.
+
+Bidirectional channel for the firmware's debug console — used by
+`rx888_tools` and host test code to receive log lines and to inject
+single-character commands.
+
+| Field         | Value                                                  |
+|---------------|--------------------------------------------------------|
+| `bRequest`    | `0xBA`                                                 |
+| `bmRequestType` | `0xC0` (IN — see notes)                              |
+| `wValue`      | 0 (poll for output) or ASCII char to push as input    |
+| `wIndex`      | 0 (ignored)                                            |
+| `wLength`     | Up to 64; firmware returns ≤ `MAXLEN_D_USB - 1 = 255` bytes total, paginated 63 bytes at a time |
+
+**Input direction:** `wValue` non-zero is interpreted as the ASCII
+code of one input character pushed to the firmware console.  `0x0D`
+(`\r`) signals "command complete" and triggers command execution.
+Other values are appended to the input buffer.
+
+**Output direction:** every call drains up to 63 bytes of pending
+debug text into the response buffer (terminated with `\0`,
+total ≤ 64 bytes).  If no debug text is queued, the firmware STALLs
+the status phase — host loops typically poll on a short interval
+until non-empty output appears.
+
+Tracing of this command is suppressed in the firmware trace stream
+(see `TraceSerial()` in `USBHandler.c:64`) — otherwise polling would
+flood the trace buffer.
+
+### HANGFX3
+
+> **Test-only.** Safe in production: the health watchdog will recover
+> within a few seconds.  Do not invoke from normal host code.
+
+Source: `SDDC_FX3/USBHandler.c:451-462`.
+
+Deterministically wedges the EP0 vendor-request handler by sleeping
+`wValue` milliseconds inside the handler thread.  Used by the host-side
+`test_health_recovery` scenario in `tests/fx3_cmd.c` to validate the
+Level-4 recovery cascade (full device reset on EP0 lockup, issues #104
+and #105).
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xCE`              |
+| `bmRequestType` | `0x40`            |
+| `wValue`      | Hang duration in ms |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 0                   |
+
+If `wValue ≥ EP0_HANDLER_TIMEOUT_MS` (2000 ms, `SDDC_FX3/health.c:30`)
+the health watchdog will fire and reset the device before the sleep
+returns.  If `wValue` is shorter, the sleep completes and the firmware
+ACKs the setup as normal.
+
+### HANGMAIN
+
+> **Test-only.** Safe in production: the FX3 hardware watchdog will
+> hard-reset the device within ~5 s.  Do not invoke from normal host
+> code.
+
+Source: `SDDC_FX3/USBHandler.c:473-478`.
+
+Arms the main thread to enter an infinite spin on its next iteration.
+The EP0 setup is ACKed immediately so the host sees a clean reply;
+the main thread freezes shortly after, the heartbeat stops, the
+WD-clear timer stops petting the FX3 HWDT, and the HWDT fires at
+`HWDT_PERIOD_MS` (5000 ms, `SDDC_FX3/health.c:53`) — hard-resetting
+the device.  Used by the host-side `test_main_recovery` scenario to
+validate Level-5 of the recovery cascade.
+
+| Field         | Value               |
+|---------------|---------------------|
+| `bRequest`    | `0xCF`              |
+| `bmRequestType` | `0x40`            |
+| `wValue`      | 0 (ignored)         |
+| `wIndex`      | 0 (ignored)         |
+| `wLength`     | 0                   |
+
+---
+
+## GPIO bit map
+
+The 32-bit control word for [`GPIOFX3`](#gpiofx3).  Pin assignments
+come from `enum GPIOPin` in `SDDC_FX3/protocol.h:62-73`.  Bits not
+listed here are ignored (no FX3 GPIO is wired up for them).
+
+| Bit | Mask         | Constant   | Function                              | Notes |
+|-----|--------------|------------|---------------------------------------|-------|
+| 5   | `0x00000020` | `SHDWN`    | Front-end shutdown line               | Active-high in the control word; drives the SHDN pin. |
+| 6   | `0x00000040` | `DITH`     | LTC2208 dither enable                 | Enables ADC dither for SFDR improvement. |
+| 7   | `0x00000080` | `RANDO`    | LTC2208 output randomization          | When set, ADC output is randomized — host must un-randomize before processing. |
+| 8   | `0x00000100` | `BIAS_HF`  | HF antenna-port bias-tee power        | |
+| 9   | `0x00000200` | `BIAS_VHF` | VHF antenna-port bias-tee power       | |
+| 11  | `0x00000800` | `LED_BLUE` | Blue front-panel LED                  | Used as a liveness/activity indicator. |
+| 13  | `0x00002000` | `ATT_SEL0` | Attenuator bank select bit 0          | Front-end RF path / attenuator selection. |
+| 14  | `0x00004000` | `ATT_SEL1` | Attenuator bank select bit 1          | |
+| 15  | `0x00008000` | `VHF_EN`   | VHF front-end enable                  | Selects the VHF path through the R828D tuner.  See the **scope and limitations** note on the [home page]({{ '/' | relative_url }}). |
+| 16  | `0x00010000` | `PGA_EN`   | PGA enable (active-low)               | The firmware inverts this bit: `mdata & PGA_EN` clears the FX3 GPIO output (`radio/rx888r2.c:25`). |
+
+> **Sticky note for host integrators.** The firmware reads each bit
+> independently — it does not maintain a per-call delta against a
+> shadow register.  Every `GPIOFX3` call sets the *full* GPIO state,
+> so each call must include the bits for any feature that should stay
+> on.
+
+---
+
+## SETARGFX3 parameter list
+
+Quick reference of the [`SETARGFX3`](#setargfx3) `wIndex` values
+recognized by this firmware.  Values not listed here STALL the status
+phase.
+
+| `wIndex` | Constant         | `wValue` range            | Default |
+|----------|------------------|---------------------------|---------|
+| 10       | `DAT31_ATT`      | 0–63                      | (unset — device boots with attenuator latched to whatever was last written) |
+| 11       | `AD8370_VGA`     | 0–255 (8-bit register)    | (unset) |
+| 14       | `WDG_MAX_RECOV`  | 0 = unlimited; 1–255      | 5 (`WDG_MAX_RECOVERY_DEFAULT`, `protocol.h:86`) |
+
+---
+
+## Test-only command behavior summary
+
+The two test commands ([`HANGFX3`](#hangfx3), [`HANGMAIN`](#hangmain))
+exist to validate the firmware's recovery layers and are safe to
+invoke against production firmware — the device self-recovers.  The
+README's "Firmware Robustness" section has the full cascade
+description.
+
+| Command  | Triggers recovery layer   | Latency to recovery | Test scenario                         |
+|----------|---------------------------|---------------------|---------------------------------------|
+| `HANGFX3`| Level 4 (`CyU3PDeviceReset`) | ~ `EP0_HANDLER_TIMEOUT_MS` (2 s) + re-enumeration | `tests/fx3_cmd.c test_health_recovery` |
+| `HANGMAIN`| Level 5 (FX3 HWDT)        | ~ `HWDT_PERIOD_MS` (5 s) | `tests/fx3_cmd.c test_main_recovery`  |
+
+---
+
+## Versioning
+
+Firmware version is exposed two ways:
+
+1. As the `glFWconfig` 16-bit field returned by [`TESTFX3`](#testfx3),
+   high byte = major, low byte = minor.
+2. As `FIRMWARE_VER_MAJOR` and `FIRMWARE_VER_MINOR` macros in
+   `SDDC_FX3/protocol.h:10-11`.
+
+Releases are tagged `vMAJOR.MINOR[.patch][-suffix]` on GitHub; see
+[Releases](https://github.com/ringof/rx888-firmware/releases).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,9 @@
+---
+title: Architecture
+nav_order: 5
+permalink: /architecture/
+---
+
 # RX888mk2 Firmware Architecture
 
 ## What the RX888mk2 is

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,61 @@
+---
+title: Building
+nav_order: 3
+permalink: /building/
+---
+
+# Building the firmware
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## Requirements
+
+- Debian or Ubuntu-based Linux distribution
+- `arm-none-eabi-gcc` toolchain (tested with 13.2.1)
+- `gcc` (host compiler, for the `elf2img` utility)
+- `make`
+
+Install the cross-compiler on Debian/Ubuntu:
+
+```
+sudo apt install gcc-arm-none-eabi
+```
+
+The Cypress FX3 SDK (v1.3.4) is included in the `SDK/` directory and
+is built as part of the firmware build — no separate SDK install
+is required.
+
+## Build
+
+```
+cd SDDC_FX3
+make clean && make all
+```
+
+This produces `SDDC_FX3.img`, the FX3 firmware image that can be
+flashed to the device.
+
+## Flashing
+
+The image is uploaded to RAM each cold boot via the FX3 BootROM USB
+protocol.  The [`rx888_tools`](https://github.com/ringof/rx888_tools)
+project ships `rx888_stream`, which acts as both the firmware uploader
+(when the device is in the bootloader state, PID `00f3`) and the IQ
+capture tool (once the firmware is running, PID `00f1`).  See the
+`rx888_tools` README for usage.
+
+For details on the BootROM protocol itself, see
+[Cypress AN76405 / EZ-USB FX3 Boot Options](https://www.cypress.com/) —
+this firmware uses the standard "RAM upload via vendor command" path.
+
+## CI builds
+
+The `build.yml` GitHub Actions workflow builds the firmware on every
+push and pull-request.  Successful builds publish `SDDC_FX3.img` as a
+workflow artifact; tagged releases publish it as a release asset via
+`release.yml`.
+
+See [Releases](https://github.com/ringof/rx888-firmware/releases) for
+the most recent firmware images.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,85 @@
+---
+title: Host application compatibility
+nav_order: 4
+permalink: /compatibility/
+---
+
+# Host application compatibility
+{: .no_toc }
+
+The firmware exposes a stable USB vendor-command interface (see
+[USB API reference]({{ '/api/' | relative_url }})) that any host
+application can drive over libusb (or a platform equivalent).  The
+list below covers known-working hosts; new hosts can be brought up
+against the API reference.
+
+1. TOC
+{:toc}
+
+## ka9q-radio
+
+[**ka9q-radio**](https://github.com/ka9q/ka9q-radio) is a
+multichannel SDR receiver with native RX888 support.  It drives the
+firmware directly via libusb: programs the Si5351 clock via I2C
+passthrough (`I2CWFX3`), controls GPIO and attenuator settings, and
+streams IQ data through the GPIF pipeline.
+
+End-to-end validation is performed via the bundled Docker test
+container in [`docker/ka9q-radio/`](https://github.com/ringof/rx888-firmware/tree/main/docker/ka9q-radio).
+The container builds only the `radiod` core, the `rx888.so` plugin,
+and control utilities.
+
+Audit notes on the compatibility boundary live at
+[ka9q-radio compatibility audit]({{ '/ka9q-compat-audit/' | relative_url }}).
+
+## rx888\_tools
+
+[**rx888\_tools**](https://github.com/ringof/rx888_tools) is the
+sibling project maintained alongside this firmware.  It provides:
+
+- `rx888_stream` — firmware uploader and USB capture tool used by
+  the test harness in `tests/`.
+- DSP utilities.
+- udev rules granting non-root access to the FX3 USB device for both
+  bootloader (`04b4:00f3`) and programmed (`04b4:00f1`) states.
+
+This repository's `tests/` tree pulls `rx888_tools` in as a submodule;
+see [Building]({{ '/building/' | relative_url }}) for the test build
+flow.
+
+## ExtIO-based Windows hosts
+
+The original
+[ExtIO\_sddc](https://github.com/ik1xpv/ExtIO_sddc) project provides
+the **ExtIO DLL** that integrates the RX888 with Windows host
+applications such as HDSDR and SDR Console.  This fork of the
+firmware is **firmware-only** and does not include the ExtIO DLL —
+Windows users should consult the upstream project for host-side
+software, but can flash an updated firmware image from this project
+once a Windows-side uploader is in place.
+
+## Writing a new host application
+
+The USB API is the only stable interface between the firmware and the
+host.  A minimal host application needs to:
+
+1. Detect the device by VID/PID (`04b4:00f3` cold, `04b4:00f1` after
+   firmware upload).
+2. Upload the firmware image via the FX3 BootROM protocol if the
+   device is in cold state.
+3. Issue [`STARTADC`]({{ '/api/' | relative_url }}#startadc) with the
+   desired ADC clock frequency in Hz.
+4. Configure the front end via
+   [`GPIOFX3`]({{ '/api/' | relative_url }}#gpiofx3) and
+   [`SETARGFX3`]({{ '/api/' | relative_url }}#setargfx3).
+5. Issue [`STARTFX3`]({{ '/api/' | relative_url }}#startfx3) and read
+   16-bit signed IQ samples from bulk endpoint `0x81`.
+6. On shutdown, issue [`STOPFX3`]({{ '/api/' | relative_url }}#stopfx3)
+   and close the device cleanly.
+
+For diagnostics, use [`GETSTATS`]({{ '/api/' | relative_url }}#getstats)
+and [`READINFODEBUG`]({{ '/api/' | relative_url }}#readinfodebug).
+The [`HANGFX3`]({{ '/api/' | relative_url }}#hangfx3) and
+[`HANGMAIN`]({{ '/api/' | relative_url }}#hangmain) test-only commands
+are useful for verifying that your host's recovery and re-enumeration
+logic handles full device resets cleanly.

--- a/docs/diagnostics_side_channel.md
+++ b/docs/diagnostics_side_channel.md
@@ -1,3 +1,9 @@
+---
+title: Diagnostics side-channel
+nav_order: 7
+permalink: /diagnostics_side_channel/
+---
+
 # Firmware-Side Diagnostics for Host Streamer Software
 
 > **Status: Partially implemented.**

--- a/docs/gpif-and-recovery.md
+++ b/docs/gpif-and-recovery.md
@@ -1,3 +1,9 @@
+---
+title: GPIF & Recovery
+nav_order: 6
+permalink: /gpif-and-recovery/
+---
+
 # GPIF State Machine and Recovery Architecture
 
 This document describes the GPIF II state machine design, the soft-stop

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+---
+title: Home
+layout: home
+nav_order: 1
+---
+
+# RX888mk2 Firmware
+
+Cypress FX3 USB controller firmware for the **RX888 mk2** direct-sampling SDR
+receiver.  HF reception (0–32 MHz) via the on-board LTC2208 ADC.
+
+[![Latest release](https://img.shields.io/github/v/release/ringof/rx888-firmware?include_prereleases&label=latest%20release)](https://github.com/ringof/rx888-firmware/releases/latest)
+[![Build](https://github.com/ringof/rx888-firmware/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ringof/rx888-firmware/actions/workflows/build.yml?query=branch%3Amain)
+
+This site is the developer-facing reference for the firmware: USB vendor
+command protocol, GPIO map, host-application compatibility, and design
+documentation.  For source and issue tracking, see the
+[GitHub repository](https://github.com/ringof/rx888-firmware).
+
+## What you'll find here
+
+- **[USB API reference]({{ '/api/' | relative_url }})** — the complete USB
+  vendor-command protocol, GPIO bit map, `SETARGFX3` arguments,
+  `GETSTATS` byte layout, and USB endpoint information.  Verified against
+  the firmware sources; each entry cites a source file and line.
+- **[Building]({{ '/building/' | relative_url }})** — toolchain, build
+  command, and how to flash a fresh image.
+- **[Host application compatibility]({{ '/compatibility/' | relative_url }})**
+  — what works with ka9q-radio, rx888\_tools, and ExtIO-based hosts.
+- **Design documentation** — [firmware architecture]({{ '/architecture/' | relative_url }}),
+  [GPIF state machine and recovery]({{ '/gpif-and-recovery/' | relative_url }}),
+  [diagnostics side-channel]({{ '/diagnostics_side_channel/' | relative_url }}),
+  [wedge detection]({{ '/wedge_detection/' | relative_url }}),
+  [license analysis]({{ '/LICENSE_ANALYSIS/' | relative_url }}).
+
+## Scope and limitations
+
+This firmware operates the **HF direct-sampling path only**.  The R828D VHF
+tuner is detected during hardware identification but is not controlled by the
+firmware — the GPL-licensed R82xx driver was removed to resolve a license
+conflict with the proprietary Cypress SDK.  VHF reception via the R828D
+requires a host-side tuner driver communicating over the I2C passthrough
+commands (`I2CWFX3`/`I2CRFX3`).
+
+## Related projects
+
+- [**ka9q-radio**](https://github.com/ka9q/ka9q-radio) — multichannel SDR
+  receiver with native RX888 support; validated end-to-end via the bundled
+  Docker test container.
+- [**rx888\_tools**](https://github.com/ringof/rx888_tools) — streamer,
+  firmware uploader, DSP utilities, and udev rules.
+- [**ExtIO\_sddc**](https://github.com/ik1xpv/ExtIO_sddc) — upstream project
+  this firmware is derived from; provides the ExtIO DLL for Windows hosts.
+
+## Acknowledgments
+
+Derived from [ExtIO\_sddc](https://github.com/ik1xpv/ExtIO_sddc) by Oscar
+Steila (IK1XPV).  Contributors to the upstream project: Howard Su, Franco
+Venturi, Hayati Ayguen, Ruslan Migirov, Vladisslav2011, Phil Ashby (phlash),
+Alberto di Bene (I2PHD), Mario Taeubel.

--- a/docs/ka9q-compat-audit.md
+++ b/docs/ka9q-compat-audit.md
@@ -1,3 +1,9 @@
+---
+title: ka9q-radio compat audit
+nav_order: 10
+permalink: /ka9q-compat-audit/
+---
+
 # ka9q-radio ↔ SDDC_FX3 Compatibility Audit
 
 Status: **initial findings, container-side patches landed**

--- a/docs/vendor-protocol-plan.md
+++ b/docs/vendor-protocol-plan.md
@@ -1,3 +1,9 @@
+---
+title: Vendor protocol plan
+nav_order: 9
+permalink: /vendor-protocol-plan/
+---
+
 # Vendor Protocol Evolution Plan
 
 **Status:** approved for execution

--- a/docs/wedge_detection.md
+++ b/docs/wedge_detection.md
@@ -1,3 +1,9 @@
+---
+title: Wedge detection
+nav_order: 8
+permalink: /wedge_detection/
+---
+
 # GPIF Clock Loss Detection and Wedge Recovery
 
 ## The problem


### PR DESCRIPTION
## Summary

Plan-only commit (so far) for setting up a GitHub Pages developer site at
`https://ringof.github.io/rx888-firmware/`, in the same vein as the
project pages used by `rx888-tools` and `ka9q-radio`.

See [`PLAN_GH_PAGES.md`](../blob/claude/setup-rx888-github-pages-hgmkB/PLAN_GH_PAGES.md)
for the full design. Highlights:

- **Hosting:** GitHub Pages via the Actions deployment source
  (`actions/deploy-pages`), Jekyll + `just-the-docs` remote theme.
- **Primary deliverable:** `docs/api.md` — a USB vendor-command
  reference verified line-by-line against `SDDC_FX3/protocol.h` and
  `SDDC_FX3/USBHandler.c`. Covers vendor commands, GPIO bits,
  `SETARGFX3` args, `GETSTATS` byte layout, VID/PID, endpoint info,
  versioning, and the test-only commands (`HANGFX3`/`HANGMAIN`).
- **Site files:** new `docs/_config.yml`, `index.md`, `api.md`,
  `building.md`, `compatibility.md`; existing seven `docs/*.md` files
  get Jekyll front-matter prepended (no body edits).
- **CI:** new `.github/workflows/pages.yml` with path filters
  (`docs/**`, `README.md`). Existing `build.yml` and `release.yml` are
  untouched.
- **Manual one-time step:** repo admin must flip Settings → Pages →
  Source to "GitHub Actions" once the workflow lands. This is not
  automatable from the PR.

## Status

**Draft / plan-only.** This PR currently contains only `PLAN_GH_PAGES.md`.
Implementation (site files + workflow) is pending plan approval.

## Test plan

Once implementation is added:

- [ ] First run of `.github/workflows/pages.yml` is green on the branch.
- [ ] After the manual Pages-source toggle, `https://ringof.github.io/rx888-firmware/`
      loads and shows the landing page.
- [ ] Sidebar lists API, Building, Compatibility, Architecture, GPIF & Recovery,
      Diagnostics, Wedge Detection, License Analysis.
- [ ] `…/api/#startfx3` (and two other command anchors) resolve.
- [ ] Spot-check three `api.md` rows against `protocol.h` and `USBHandler.c`.
- [ ] `make -C SDDC_FX3 clean all` still produces `SDDC_FX3.img` (regression).
- [ ] `build.yml` and `release.yml` runs are unaffected on this branch
      (regression).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DU2R1wCUTZToMbw9qoRj5b)_