### PR TITLE
release(v0.1.0-prep): bump firmware to 2.3 + docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,34 @@
 name: build
 
+# Skip the firmware/host build when a push or PR touches only
+# documentation-class files.  The Pages workflow (pages.yml) handles
+# docs/README rebuilds separately; running the firmware build for a
+# Markdown-only change wastes ~2 minutes of runner time per PR.
+#
+# GitHub treats `paths-ignore` as "skip iff EVERY changed path
+# matches" -- a PR that mixes docs and code still runs the build.
+#
+# If `build / firmware` or `build / host-tests` is a required status
+# check in branch protection, a docs-only PR may stall waiting for a
+# check that no longer runs.  Adjust the rule (or add a stub job
+# with the inverse path filter) in that case.
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'SDDC_FX3/docs/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'SDDC_FX3/docs/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE*'
+      - '.gitignore'
 
 jobs:
   firmware:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,3 @@ First named release.  Firmware version **2.3** (`FIRMWARE_VER_MAJOR=2`,
   ([#113](https://github.com/ringof/rx888-firmware/issues/113)).
 - Broader doc audit pending
   ([#114](https://github.com/ringof/rx888-firmware/issues/114)).
-
-## [0.1.0-rc0]
-
-Pre-release.  See git history for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this firmware are documented here.
+
+The format is loosely based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
+uses [semantic-ish versioning](https://semver.org/) — see the
+[releases page](https://github.com/ringof/rx888-firmware/releases) for
+the canonical list of artifacts.
+
+Firmware-reported version (`FIRMWARE_VER_MAJOR.FIRMWARE_VER_MINOR` in
+`SDDC_FX3/protocol.h`, queryable via the `TESTFX3` vendor command) is
+tracked separately from the repo release tag and is noted per-release
+below where it changes.
+
+## [Unreleased]
+
+_No changes yet._
+
+## [0.1.0] — 2026-05-14
+
+First named release.  Firmware version **2.3** (`FIRMWARE_VER_MAJOR=2`,
+`FIRMWARE_VER_MINOR=3`).
+
+### Highlights
+
+- **ka9q-radio runs without host-side patches.**  Firmware now reports
+  Si5351 CLK0 state truthfully, so ka9q-radio's direct Si5351
+  programming path passes the `STARTFX3` preflight without needing a
+  redundant `STARTADC`.  The container's patch 03 has been retired.
+- **5-level recovery cascade** for streaming wedges, EP0 stalls, and
+  main-thread freezes — including FX3 hardware-watchdog fallback for
+  the worst-case lockup.  Validated under multi-hour soak.
+- **GitHub Pages developer site** at
+  [ringof.github.io/rx888-firmware](https://ringof.github.io/rx888-firmware/)
+  with a complete USB API reference verified against the C source
+  line-by-line.
+
+### Added
+
+- Live Si5351 CLK0_CONTROL register read inside
+  `si5351_clk0_enabled()`; removed the `glAdcClockEnabled`
+  host-cache flag.  (`SDDC_FX3/driver/Si5351.c`, PR #122.)
+- `GETSTATS` reply extended from 24 to 26 bytes — new offsets:
+  [24] raw CLK0_CONTROL register byte, [25] boolean chip-query
+  result.  Backwards compatible: hosts that still request `wLength=24`
+  continue to work.  (`SDDC_FX3/USBHandler.c`.)
+- `clk0_chip_query` soak scenario that exercises the live I2C
+  preflight check.  (`tests/fx3_cmd.c`.)
+- `soak --weight NAME=N` / `-w NAME=N` flag to bias scenario rotation
+  for context-dependent failure hunts.  (`tests/fx3_cmd.c`.)
+- GitHub Pages site: `docs/_config.yml`, `docs/index.md`, `docs/api.md`
+  (USB vendor-command reference), `docs/building.md`,
+  `docs/compatibility.md`, plus Jekyll front-matter on existing docs.
+  Workflow `.github/workflows/pages.yml`.  (PR #121.)
+- `CHANGELOG.md` (this file).
+
+### Changed
+
+- `docker/ka9q-radio/patches/03-startadc-before-startfx3.patch` renamed
+  to `…patch.disabled`; kept in-tree for archaeology.  Dockerfile loop
+  hardened with a POSIX empty-glob guard so a zero-active-patch build
+  succeeds cleanly.  (PR #122.)
+- `docs/ka9q-compat-audit.md` §8 reframed: original failure mode
+  preserved for context, but marked resolved firmware-side.
+- `docs/vendor-protocol-plan.md` commits 1 and 2 marked DONE; commits
+  3 (`GETCAPABILITIES`, `GETSTATE`) and 4 (architecture docs) remain
+  open.
+
+### Fixed
+
+- `STARTFX3` preflight no longer rejects ka9q-radio's direct Si5351
+  programming path with `LIBUSB_ERROR_PIPE` / EP0 STALL → "No rx888
+  data for 5 seconds, quitting".
+
+### Known issues
+
+- Cold-start `startadc_mid_stream` flake at the very first scenario
+  after firmware boot (≈ once per multi-thousand-cycle soak).
+  Tracked in [#119](https://github.com/ringof/rx888-firmware/issues/119).
+- Intermittent failures in `setarg_gap_index`
+  ([#111](https://github.com/ringof/rx888-firmware/issues/111)) and
+  `test_health_recovery`
+  ([#113](https://github.com/ringof/rx888-firmware/issues/113)).
+- Broader doc audit pending
+  ([#114](https://github.com/ringof/rx888-firmware/issues/114)).
+
+## [0.1.0-rc0]
+
+Pre-release.  See git history for details.

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Recovery is owned by a single module — `SDDC_FX3/health.c` — that
 collects liveness signals from across the firmware and applies a
 documented cascade of remedies when the device is unhealthy.  This
 section describes the architecture and the implementation status of
-each cascade level.  See `PLAN_RECOVERY.md` at the repo root for the
-design rationale and PR sequencing.
+each cascade level.  See `docs/archive/PLAN_RECOVERY.md` for the
+original design rationale and PR sequencing.
 
 ### Health interface
 
@@ -145,7 +145,7 @@ a new evaluation branch — not writing a new watchdog.
 
 | Level | Remedy | Appropriate for | Latency | Status |
 |---|---|---|---|---|
-| 1 | Soft-stop FW_TRG + `DmaMultiChannelReset` + `GpifSMStart` | Streaming wedge | ~300 ms | **Implemented** (existing watchdog in `RunApplication.c`; pending migration into `health_recover()` per `PLAN_RECOVERY.md` §5 PR N) |
+| 1 | Soft-stop FW_TRG + `DmaMultiChannelReset` + `GpifSMStart` | Streaming wedge | ~300 ms | **Implemented** (existing watchdog in `RunApplication.c`; pending migration into `health_recover()` — issue #115) |
 | 2 | EP0 stall+unstall + `FlushEp` on EP1 | EP0 stuck state | ~10 ms | **Not implemented yet** |
 | 3 | `StopApplication` + `StartApplication` | Application-level state corruption | ~100 ms | **Not implemented yet** |
 | 4 | `CyU3PDeviceReset(CyFalse)` | Vendor-handler hang (EP0 thread deadlocked in an SDK call) | full re-enumeration (~1-2 s) | **Implemented** in `health_recover(HEALTH_WEDGED_EP0)` (#104, #105).  Validated end-to-end by `test_health_recovery` (HANGFX3). |

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@
 
 **Documentation:** [ringof.github.io/rx888-firmware](https://ringof.github.io/rx888-firmware/) — USB API reference, GPIO map, host-application compatibility, and architecture notes.
 
-Cypress FX3 USB controller firmware for the **RX888 mk2** (also written
-RX888mk2) direct-sampling SDR receiver. HF reception (0–32 MHz) via the
-on-board LTC2208 ADC; the R828D VHF tuner is detected but not driven by
-the firmware (see Limitations).
+Open-source Cypress FX3 firmware for the **RX888 mk2** (also written
+RX888mk2) direct-sampling SDR receiver.  If you're about to write FX3
+firmware for an SDR — USB vendor-command protocol, GPIF II state
+machine, DMA pipeline, Si5351 clock control, ka9q-radio compatibility,
+recovery cascade with streaming watchdog and FX3 hardware-watchdog
+backstop — start here, not from scratch.  HF reception 0–32 MHz via
+the on-board LTC2208 ADC; the R828D VHF tuner is detected but not
+driven by the firmware (see Limitations).
 
 ## Compatible host applications
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Latest release](https://img.shields.io/github/v/release/ringof/rx888-firmware?include_prereleases&label=latest%20release)](https://github.com/ringof/rx888-firmware/releases/latest)
 [![Build](https://github.com/ringof/rx888-firmware/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ringof/rx888-firmware/actions/workflows/build.yml?query=branch%3Amain)
 
+**Documentation:** [ringof.github.io/rx888-firmware](https://ringof.github.io/rx888-firmware/) — USB API reference, GPIO map, host-application compatibility, and architecture notes.
+
 Cypress FX3 USB controller firmware for the **RX888 mk2** (also written
 RX888mk2) direct-sampling SDR receiver. HF reception (0–32 MHz) via the
 on-board LTC2208 ADC; the R828D VHF tuner is detected but not driven by

--- a/SDDC_FX3/docs/debugging.md
+++ b/SDDC_FX3/docs/debugging.md
@@ -350,12 +350,14 @@ Read-only EP0 vendor request (IN direction):
 bRequest = 0xB3 (GETSTATS)
 wValue   = 0
 wIndex   = 0
-wLength  = 20
+wLength  = 26    (firmware sends exactly 26 bytes; host may request
+                  fewer and the firmware will truncate to the
+                  requested length)
 ```
 
 ### Response Layout
 
-20 bytes, packed, little-endian (native ARM byte order):
+26 bytes, packed, little-endian (native ARM byte order):
 
 | Offset | Size | Field | Source |
 |--------|------|-------|--------|
@@ -364,8 +366,11 @@ wLength  = 20
 | 5--8 | 4 | PIB error count | `glCounter[0]`, incremented in `PibErrorCallback` |
 | 9--10 | 2 | Last PIB error arg | `glLastPibArg`, saved in `PibErrorCallback` |
 | 11--14 | 4 | I2C failure count | `glCounter[1]`, incremented in `I2cTransfer` on error |
-| 15--18 | 4 | Watchdog recovery count | `glCounter[2]`, incremented by GPIF watchdog on each recovery (see section 5) |
+| 15--18 | 4 | Streaming fault count | `glCounter[2]`, incremented by GPIF watchdog on each recovery + on EP underruns (see section 5) |
 | 19 | 1 | Si5351 status (reg 0) | `I2cTransfer(0x00, 0xC0, …)` sampled at read time |
+| 20--23 | 4 | `boot_count` | `health_boot_count()`; increments once per `health_init()`.  Use to detect mid-test resets (Level 4 `CyU3PDeviceReset`, Level 5 HWDT, manual `RESETFX3`, or power cycle): snapshot before, compare after, mismatch means the device reset. |
+| 24 | 1 | Si5351 CLK0_CONTROL (reg 16) | Live `I2cTransfer(0x10, 0xC0, …)`.  Bit 7 is `CLK0_PDN`: set means CLK0 is powered down, clear means CLK0 is enabled.  Returns `0xFF` if the I2C read fails. |
+| 25 | 1 | `clk0_result` | `si5351_clk0_enabled()` (1 = CLK0 enabled, 0 = disabled or I2C error).  Same value `GpifPreflightCheck()` consults at `STARTFX3` time. |
 
 ### Counter Behavior
 
@@ -521,7 +526,7 @@ Runs 36 tests (39 with streaming) in TAP format:
 | 19 | Debug buffer race | 50 rapid poll cycles survive (issue #8) |
 | 20 | Debug console over USB | `?` command returns help text (issue #26) |
 | 21 | Stack watermark | Free > 25% of 2048 bytes after init (issue #12) |
-| 22 | GETSTATS readout | GETSTATS (0xB3) returns 20 bytes with sane values |
+| 22 | GETSTATS readout | GETSTATS (0xB3) returns 26 bytes with sane values |
 | 23 | GETSTATS I2C counter | I2C failure count increments after NACK on absent address |
 | 24 | GETSTATS PLL status | Si5351 PLL A locked, SYS_INIT clear |
 | 25 | GPIF stop state | GPIF SM state is 0, 1, or 255 after STOPFX3 (not stuck in read) |

--- a/SDDC_FX3/health.c
+++ b/SDDC_FX3/health.c
@@ -9,7 +9,7 @@
  * and Levels 1-4 (which all depend on the main thread to fire) become
  * unreachable.  Health.c is the only place HWDT is configured/petted.
  *
- * See health.h for the contract and PLAN_RECOVERY.md for design notes.
+ * See health.h for the contract and docs/archive/PLAN_RECOVERY.md for design notes.
  *
  * The discipline rule: new recovery code MUST extend one of these
  * functions.  Do not invent parallel mechanisms.  Do not add inline
@@ -174,7 +174,7 @@ health_status_t health_evaluate(void)
 
 void health_recover(health_status_t status)
 {
-    /* See PLAN_RECOVERY.md §4 for the documented cascade levels.
+    /* See docs/archive/PLAN_RECOVERY.md §4 for the documented cascade levels.
      * PR 2 implements Level 4 only.  Future PRs add Levels 2, 3, 5
      * and migrate Level 1 (streaming watchdog). */
     switch (status) {

--- a/SDDC_FX3/health.h
+++ b/SDDC_FX3/health.h
@@ -22,8 +22,8 @@
  * Adding a new failure-mode detection means adding a new event type
  * and a new evaluation branch — NOT writing a new watchdog.
  *
- * See PLAN_RECOVERY.md at the repo root for full design notes and the
- * recovery cascade table.
+ * See docs/archive/PLAN_RECOVERY.md for the original design notes
+ * and recovery cascade table.
  */
 
 #ifndef _INCLUDED_HEALTH_H_
@@ -48,7 +48,8 @@ typedef enum {
 
 /* One-time initialization.  Called once at firmware boot before any
  * other health_*() function.  Configures the FX3 hardware watchdog
- * timer (Level 5 catastrophic backstop) — see PLAN_RECOVERY.md §4. */
+ * timer (Level 5 catastrophic backstop) — see
+ * docs/archive/PLAN_RECOVERY.md §4. */
 void health_init(void);
 
 /* HWDT pet is handled internally by a ThreadX timer set up in

--- a/SDDC_FX3/protocol.h
+++ b/SDDC_FX3/protocol.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #define FIRMWARE_VER_MAJOR 2
-#define FIRMWARE_VER_MINOR 2
+#define FIRMWARE_VER_MINOR 3
 
 /* USB vendor request command codes (bRequest field in SETUP packet) */
 enum FX3Command {

--- a/docker/ka9q-radio/patches/README.md
+++ b/docker/ka9q-radio/patches/README.md
@@ -20,16 +20,17 @@ build succeeds with zero patches applied.
 The audit (`docs/ka9q-compat-audit.md`) identified two further
 ka9q-side behaviors that are observable but not blocking:
 
-- **`sleep(1)` after firmware upload** (`rx888.c:700`).  Upstream's
-  fixed 1 s wait is fragile in principle, but it is sufficient on
-  every host we have tested when the container is run with
-  `-v /run/udev:/run/udev:ro` (so libusb's hotplug listener sees
+- **`sleep(1)` after firmware upload** in ka9q's `rx888_usb_init()`.
+  Upstream's fixed 1 s wait is fragile in principle, but it is
+  sufficient on every host we have tested when the container is run
+  with `-v /run/udev:/run/udev:ro` (so libusb's hotplug listener sees
   fresh device events).  A polling loop would be more robust on
   pathologically slow hosts but is not required.  Documented in
   audit §1.
 
-- **`TUNERSTDBY` (0xB8) on the HF path** (`rx888.c:943`,
-  `rx888.c:1003`).  Returns a clean USB STALL from SDDC firmware's
-  default handler; ka9q's `command_send` ignores the return value,
-  so streaming is unaffected.  Cosmetic only — the bus is noisier
-  than it needs to be.  Documented in audit §2.
+- **`TUNERSTDBY` (0xB8) on the HF path** in ka9q's
+  `rx888_set_hf_mode()` and `rx888_start_rx()`.  Returns a clean USB
+  STALL from SDDC firmware's default handler; ka9q's `command_send`
+  ignores the return value, so streaming is unaffected.  Cosmetic
+  only — the bus is noisier than it needs to be.  Documented in
+  audit §2.

--- a/docs/LICENSE_ANALYSIS.md
+++ b/docs/LICENSE_ANALYSIS.md
@@ -2,6 +2,7 @@
 title: License analysis
 nav_order: 11
 permalink: /LICENSE_ANALYSIS/
+description: License analysis of the RX888mk2 FX3 firmware - MIT application code, proprietary Cypress FX3 SDK / ThreadX RTOS, why the GPL R82xx driver was removed.
 ---
 
 # License Analysis

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -34,3 +34,4 @@ footer_content: >-
 plugins:
   - jekyll-remote-theme
   - jekyll-seo-tag
+  - jekyll-sitemap

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,3 +35,9 @@ plugins:
   - jekyll-remote-theme
   - jekyll-seo-tag
   - jekyll-sitemap
+
+# Search-engine site ownership verification.  Each entry is emitted
+# by jekyll-seo-tag as a <meta> tag in <head>.  Google verification
+# is handled at the root domain (DNS-level), so no key is needed here.
+webmaster_verifications:
+  bing: 3804FF063F01EBF3145B8D4D3EF09208

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,8 +12,8 @@ image.  Every claim on this page cites a source file and line in the
 firmware tree; if behavior differs between this page and the source, the
 source is authoritative — please open an issue.
 
-Reference firmware version: **2.2**
-(`FIRMWARE_VER_MAJOR=2`, `FIRMWARE_VER_MINOR=2` —
+Reference firmware version: **2.3**
+(`FIRMWARE_VER_MAJOR=2`, `FIRMWARE_VER_MINOR=3` —
 `SDDC_FX3/protocol.h:10-11`).
 
 1. TOC

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,7 @@
 title: USB API reference
 nav_order: 2
 permalink: /api/
+description: Complete USB vendor-command protocol for the RX888mk2 FX3 firmware - STARTFX3, STOPFX3, GETSTATS 26-byte layout, SETARGFX3, GPIO bitmap, Si5351 I2C.
 ---
 
 # USB API reference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,9 +219,9 @@ The firmware controls the GPIF via a software input signal
 
 The application thread monitors `glDMACount` every 100 ms while
 streaming is active.  If the count stalls for 3 consecutive polls
-(300 ms) with the SM in a BUSY/WAIT state (5, 7, 8, 9), the watchdog
-tears down and rebuilds the pipeline -- same sequence as STOP + START
-but initiated automatically.  If the PLL has lost lock, the watchdog
+(300 ms) with the SM in a BUSY/WAIT state, the watchdog tears down
+and rebuilds the pipeline -- same sequence as STOP + START but
+initiated automatically.  If the PLL has lost lock, the watchdog
 leaves the pipeline stopped and waits for the host to reconfigure.
 Each recovery increments `glCounter[2]` (visible via `GETSTATS`).
 
@@ -238,7 +238,22 @@ on all active states that can stall, enabling clean soft-stop without
 DMA debris.  STOPFX3 and the watchdog deassert FW_TRG, verify the SM
 reached IDLE, then disable — falling back to force-stop only if the
 external clock is dead.  See [gpif-and-recovery.md](gpif-and-recovery.md)
-for the full state machine design and recovery architecture.
+for the full state machine design and GPIF-level recovery details.
+
+**Wider recovery cascade:**
+
+The GPIF watchdog is one level of a broader recovery cascade.  The
+firmware also detects EP0 vendor-handler hangs (Level 4, in
+`SDDC_FX3/health.c`) and main-thread death via the FX3 hardware
+watchdog (Level 5, configured in `health.c` and petted by a
+heartbeat-gated ThreadX timer).  Test-only vendor commands `HANGFX3`
+(0xCE) and `HANGMAIN` (0xCF) force each failure mode for round-trip
+validation.  A `boot_count` value in `GETSTATS` lets a host detect
+that the device reset between two snapshots regardless of cause.
+
+The cascade is canonically documented in the
+[README "Firmware Robustness" section](https://github.com/ringof/rx888-firmware#firmware-robustness).
+See `docs/archive/PLAN_RECOVERY.md` for the original design rationale.
 
 ---
 
@@ -521,17 +536,19 @@ endpoint zero.  The host sends a SETUP packet with a vendor-specific
 
 | bRequest | Name | Dir | wValue | wIndex | Data | Description |
 |----------|------|-----|--------|--------|------|-------------|
-| 0xAA | STARTFX3 | OUT | -- | -- | 4 B | Start GPIF streaming; preflight-checks PLL lock, force-stops any stuck SM, resets DMA, reloads waveform, asserts FW_TRG; STALLs if PLL unlocked |
-| 0xAB | STOPFX3 | OUT | -- | -- | 4 B | Stop GPIF streaming; de-asserts FW_TRG, force-disables GPIF (no waveform reload), resets DMA, flushes EP1 |
+| 0xAA | STARTFX3 | OUT | -- | -- | 0 B | Start GPIF streaming; preflight-checks PLL lock, force-stops any stuck SM, resets DMA, reloads waveform, asserts FW_TRG; STALLs if PLL unlocked |
+| 0xAB | STOPFX3 | OUT | -- | -- | 0 B | Stop GPIF streaming; de-asserts FW_TRG, soft-disables GPIF (force-stop fallback if SM did not reach IDLE), resets DMA, flushes EP1 |
 | 0xAC | TESTFX3 | IN | debug | -- | 4 B | Query device info; returns [glHWconfig, FW_major, FW_minor, glVendorRqtCnt]; wValue=1 enables debug mode |
 | 0xAD | GPIOFX3 | OUT | -- | -- | 4 B | Set GPIO state; payload is a 32-bit bitmask interpreted by `rx888r2_GpioSet()` |
 | 0xAE | I2CWFX3 | OUT | I2C addr | reg addr | N B | Write N bytes to I2C device at wValue, register wIndex |
 | 0xAF | I2CRFX3 | IN | I2C addr | reg addr | N B | Read N bytes from I2C device |
-| 0xB1 | RESETFX3 | OUT | -- | -- | 4 B | Warm-reset the FX3; device disconnects and returns to bootloader |
+| 0xB1 | RESETFX3 | OUT | -- | -- | 0 B | Warm-reset the FX3; device disconnects and returns to bootloader |
 | 0xB2 | STARTADC | OUT | -- | -- | 4 B | Set ADC sampling clock; payload is frequency in Hz, programs Si5351 PLL A / CLK0; STALLs EP0 if Si5351 I2C fails |
 | 0xB3 | GETSTATS | IN | 0 | 0 | 26 B | Read diagnostic counters: DMA count (4), GPIF state (1), PIB errors (4), last PIB arg (2), I2C failures (4), streaming faults (4), Si5351 status (1), boot count (4), Si5351 CLK0_CONTROL (1), clk0_result (1).  See [api.md §GETSTATS](api.md) for the canonical layout. |
-| 0xB6 | SETARGFX3 | OUT | value | arg_id | 1 B | Set hardware parameter; arg_id 10 = PE4304 attenuator (0-63), arg_id 11 = AD8370 VGA (0-255) |
-| 0xBA | READINFODEBUG | IN | char | -- | 100 B | Debug console: wValue carries one input character (0 = none); response is buffered debug output (STALL if empty) |
+| 0xB6 | SETARGFX3 | OUT | value | arg_id | N B | Set hardware parameter; arg_id 10 = PE4304 attenuator (0-63), arg_id 11 = AD8370 VGA (0-255), arg_id 14 = `WDG_MAX_RECOV` watchdog recovery cap |
+| 0xBA | READINFODEBUG | IN | char | -- | ≤ 64 B | Debug console: wValue carries one input character (0 = none); response is buffered debug output (STALL if empty) |
+| 0xCE | HANGFX3 | OUT | sleep ms | -- | 0 B | **Test-only.** Sleeps `wValue` ms inside the EP0 handler to deterministically wedge the vendor callback; used by `test_health_recovery` to validate the Level-4 EP0 watchdog. |
+| 0xCF | HANGMAIN | OUT | -- | -- | 0 B | **Test-only.** Sets a flag that causes the main loop to spin forever on its next iteration; used by `test_main_recovery` to validate the Level-5 FX3 HWDT backstop. |
 
 ### EP0 buffer overflow protection
 
@@ -641,8 +658,11 @@ When the host sends `STARTADC` with a target frequency:
 
 Each I2C step checks the return status; if any step fails the command
 STALLs EP0 and the failure is logged via `DebugPrint`.  On success the
-firmware sleeps 1000 ms after programming the clock to allow the PLL
-to settle.  A frequency of 0 disables CLK0 output (single I2C write).
+firmware polls `si5351_pll_locked()` (Si5351 register 0 bit 5) for up
+to ~100 ms, returning as soon as PLL A reports lock — this keeps the
+EP0 thread unblocked so a `STARTFX3` arriving shortly after a frequency
+change is not delayed by the worst-case settle time.  A frequency of 0
+disables CLK0 output (single I2C write).
 
 ---
 
@@ -799,22 +819,24 @@ every vendor command through `fx3_cmd`.
 
 ## Source file reference
 
-| File | Lines | Purpose |
-|------|-------|---------|
-| `SDDC_FX3/StartUp.c` | 82 | ARM entry point, clock config, I/O matrix, RTOS start |
-| `SDDC_FX3/RunApplication.c` | 362 | Application thread, hardware detection, main loop, GPIF watchdog |
-| `SDDC_FX3/USBHandler.c` | 574 | USB setup callback (all vendor commands), USB init |
-| `SDDC_FX3/StartStopApplication.c` | 212 | GPIF/DMA/endpoint configuration, start/stop streaming, preflight check |
-| `SDDC_FX3/DebugConsole.c` | 349 | UART init, debug buffer, console parser, USB debug |
-| `SDDC_FX3/USBDescriptor.c` | 299 | USB descriptors (SS, HS, FS, BOS, strings, serial number) |
-| `SDDC_FX3/Support.c` | 185 | Error code lookup, status checking, error LED blink |
-| `SDDC_FX3/i2cmodule.c` | 90 | I2C master init and transfer functions |
-| `SDDC_FX3/driver/Si5351.c` | 328 | Si5351 clock synthesizer: PLL setup, frequency calculation, lock status |
-| `SDDC_FX3/radio/rx888r2.c` | 89 | RX888mk2 hardware abstraction: GPIO, attenuator, VGA |
-| `SDDC_FX3/Application.h` | 96 | Central header: includes, defines, prototypes |
-| `SDDC_FX3/protocol.h` | 84 | USB protocol: vendor request codes, GPIO enums, arguments |
-| `SDDC_FX3/SDDC_GPIF.h` | 173 | Generated GPIF II state machine configuration |
-| `SDDC_FX3/cyfxtx.c` | -- | Cypress SDK memory and TX runtime support |
-| `SDDC_FX3/cyfx_gcc_startup.S` | -- | ARM GCC startup assembly (vectors, stack init) |
-| `tests/fx3_cmd.c` | 4990 | Host-side vendor command exerciser, soak test harness (libusb) |
+| File | Purpose |
+|------|---------|
+| `SDDC_FX3/StartUp.c` | ARM entry point, clock config, I/O matrix, RTOS start |
+| `SDDC_FX3/RunApplication.c` | Application thread, hardware detection, main loop, GPIF streaming watchdog, recovery cascade integration |
+| `SDDC_FX3/USBHandler.c` | USB setup callback (all vendor commands), USB init, EP0 liveness reporting into `health.c` |
+| `SDDC_FX3/StartStopApplication.c` | GPIF/DMA/endpoint configuration, start/stop streaming, preflight check |
+| `SDDC_FX3/DebugConsole.c` | UART init, debug buffer, console parser, USB debug |
+| `SDDC_FX3/USBDescriptor.c` | USB descriptors (SS, HS, FS, BOS, strings, serial number) |
+| `SDDC_FX3/Support.c` | Error code lookup, status checking, error LED blink |
+| `SDDC_FX3/i2cmodule.c` | I2C master init and transfer functions |
+| `SDDC_FX3/health.c` | Recovery cascade owner: EP0 vendor-handler liveness check (Level 4 device reset) and FX3 hardware watchdog configuration / petting (Level 5).  `boot_count` source. |
+| `SDDC_FX3/health.h` | Recovery cascade interface (three-function contract: `health_record_event`, `health_evaluate`, `health_recover`) |
+| `SDDC_FX3/driver/Si5351.c` | Si5351 clock synthesizer: PLL setup, frequency calculation, lock status, CLK0 chip query |
+| `SDDC_FX3/radio/rx888r2.c` | RX888mk2 hardware abstraction: GPIO, attenuator, VGA |
+| `SDDC_FX3/Application.h` | Central header: includes, defines, prototypes |
+| `SDDC_FX3/protocol.h` | USB protocol: vendor request codes, GPIO enums, arguments |
+| `SDDC_FX3/SDDC_GPIF.h` | Generated GPIF II state machine configuration |
+| `SDDC_FX3/cyfxtx.c` | Cypress SDK memory and TX runtime support |
+| `SDDC_FX3/cyfx_gcc_startup.S` | ARM GCC startup assembly (vectors, stack init) |
+| `tests/fx3_cmd.c` | Host-side vendor command exerciser, soak test harness (libusb) |
 | `tests/fw_test.sh` | 731 | TAP test harness for automated firmware testing (36 tests + 3 streaming) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,7 @@
 title: Architecture
 nav_order: 5
 permalink: /architecture/
+description: RX888mk2 FX3 firmware architecture - hardware overview, GPIF II, DMA pipeline, ThreadX RTOS, vendor commands, recovery cascade, Si5351 clock, debug paths.
 ---
 
 # RX888mk2 Firmware Architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -529,7 +529,7 @@ endpoint zero.  The host sends a SETUP packet with a vendor-specific
 | 0xAF | I2CRFX3 | IN | I2C addr | reg addr | N B | Read N bytes from I2C device |
 | 0xB1 | RESETFX3 | OUT | -- | -- | 4 B | Warm-reset the FX3; device disconnects and returns to bootloader |
 | 0xB2 | STARTADC | OUT | -- | -- | 4 B | Set ADC sampling clock; payload is frequency in Hz, programs Si5351 PLL A / CLK0; STALLs EP0 if Si5351 I2C fails |
-| 0xB3 | GETSTATS | IN | 0 | 0 | 20 B | Read diagnostic counters: DMA count (4), GPIF state (1), PIB errors (4), last PIB arg (2), I2C failures (4), watchdog recoveries (4), Si5351 status (1) |
+| 0xB3 | GETSTATS | IN | 0 | 0 | 26 B | Read diagnostic counters: DMA count (4), GPIF state (1), PIB errors (4), last PIB arg (2), I2C failures (4), streaming faults (4), Si5351 status (1), boot count (4), Si5351 CLK0_CONTROL (1), clk0_result (1).  See [api.md §GETSTATS](api.md) for the canonical layout. |
 | 0xB6 | SETARGFX3 | OUT | value | arg_id | 1 B | Set hardware parameter; arg_id 10 = PE4304 attenuator (0-63), arg_id 11 = AD8370 VGA (0-255) |
 | 0xBA | READINFODEBUG | IN | char | -- | 100 B | Debug console: wValue carries one input character (0 = none); response is buffered debug output (STALL if empty) |
 

--- a/docs/archive/PLAN_GH_PAGES.md
+++ b/docs/archive/PLAN_GH_PAGES.md
@@ -1,5 +1,9 @@
 # PLAN — GitHub Pages site for rx888-firmware
 
+> **Status: archived.**  This plan shipped in PR #121.  The site is
+> live at https://ringof.github.io/rx888-firmware/ and the source
+> lives under `docs/`.  This document is preserved for design rationale.
+
 ## Goal
 
 Stand up a public project page at

--- a/docs/archive/PLAN_RECOVERY.md
+++ b/docs/archive/PLAN_RECOVERY.md
@@ -1,5 +1,13 @@
 # Plan: Recovery Architecture via `health.c`
 
+> **Status: archived.**  The cascade described here shipped in PR #112
+> (Levels 1, 4, 5).  This document is preserved for design rationale —
+> see `README.md` §"Firmware Robustness" for the canonical current
+> description of the implemented cascade.  The one remaining item — §5
+> "PR N (deferred)", migrating the existing streaming watchdog from
+> `RunApplication.c` into `health_recover(WEDGED_STREAMING)` — is now
+> tracked as issue #115.
+
 ## 1. Context and motivation
 
 The 1-hour soak on `main` produced one transient `rapid_start_stop` failure

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,6 +2,7 @@
 title: Building
 nav_order: 3
 permalink: /building/
+description: How to build the RX888mk2 Cypress FX3 firmware from source with arm-none-eabi-gcc on Debian/Ubuntu, and how to flash a fresh image to the device.
 ---
 
 # Building the firmware

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,6 +2,7 @@
 title: Host application compatibility
 nav_order: 4
 permalink: /compatibility/
+description: Host application compatibility for the RX888mk2 firmware - ka9q-radio (Docker container), rx888_tools / rx888_stream, ExtIO-based Windows hosts.
 ---
 
 # Host application compatibility

--- a/docs/diagnostics_side_channel.md
+++ b/docs/diagnostics_side_channel.md
@@ -2,6 +2,7 @@
 title: Diagnostics side-channel
 nav_order: 7
 permalink: /diagnostics_side_channel/
+description: GETSTATS (0xB3) - a 26-byte EP0 vendor request that exposes FX3 firmware counters - DMA progress, GPIF state, PIB errors, Si5351 PLL/CLK0, boot count.
 ---
 
 # Firmware-Side Diagnostics for Host Streamer Software

--- a/docs/diagnostics_side_channel.md
+++ b/docs/diagnostics_side_channel.md
@@ -9,10 +9,12 @@ permalink: /diagnostics_side_channel/
 > **Status: Partially implemented.**
 >
 > The core diagnostic side-channel is live as **GETSTATS (`0xB3`)**, a
-> 20-byte EP0 vendor request returning DMA counts, GPIF state, PIB
-> error counts, I2C failure counts, streaming fault counts, and Si5351 PLL status.  See
-> [`SDDC_FX3/docs/debugging.md` §5](../SDDC_FX3/docs/debugging.md) for
-> the implemented wire format and host usage.
+> 26-byte EP0 vendor request returning DMA counts, GPIF state, PIB
+> error counts, I2C failure counts, streaming-fault counts, Si5351
+> PLL status, boot count, and Si5351 CLK0 power-state diagnostics.
+> See [`api.md` §GETSTATS](api.md) for the canonical wire format and
+> [`SDDC_FX3/docs/debugging.md` §6](../SDDC_FX3/docs/debugging.md)
+> for host-side usage examples.
 >
 > The extended `DIAGFX3` (`0xB7`) command and the 24-byte `fx3_diag_t`
 > structure described in §§ "Future extensions" below remain **design
@@ -76,6 +78,9 @@ and alignment ambiguity on the ARM926EJ-S target.
 | 11--14 | 4    | I2C failure count      | *(not in proposal)* | **Implemented** (bonus diagnostic) |
 | 15--18 | 4    | Streaming fault count  | `streaming_faults` | **Implemented** (EP underruns + watchdog recoveries) |
 | 19     | 1    | Si5351 status (reg 0)  | `si5351_status`   | **Implemented** |
+| 20--23 | 4    | `boot_count`           | *(not in proposal)* | **Implemented** (per-boot counter for mid-test reset detection) |
+| 24     | 1    | Si5351 CLK0_CONTROL (reg 16) | *(not in proposal)* | **Implemented** (live read; bit 7 = CLK0_PDN) |
+| 25     | 1    | `clk0_result`          | *(not in proposal)* | **Implemented** (`si5351_clk0_enabled()`; same value `GpifPreflightCheck()` consults) |
 
 **Not yet implemented** from the original proposal:
 
@@ -146,13 +151,15 @@ count) as a superset.
 
 ### Chosen: New vendor command via EP0 (Option A)
 
-**Implemented as GETSTATS (`0xB3`), 20 bytes.**  This follows Option A
+**Implemented as GETSTATS (`0xB3`), 26 bytes.**  This follows Option A
 from the original proposal — a dedicated vendor request returning
 diagnostic counters via EP0, independent of the bulk data stream.
 
 ```
-Host sends:  bRequest=0xB3, wValue=0, wIndex=0, wLength=20, direction=IN
-FX3 returns: 20 bytes, packed little-endian (see debugging.md §5 for layout)
+Host sends:  bRequest=0xB3, wValue=0, wIndex=0, wLength=26, direction=IN
+FX3 returns: 26 bytes, packed little-endian (see api.md §GETSTATS for
+             the canonical layout, or SDDC_FX3/docs/debugging.md §6
+             for the firmware-side view)
 ```
 
 The host calls this periodically (every 100-500 ms) alongside its
@@ -408,7 +415,7 @@ int ret = libusb_control_transfer(dev,
 **Actual cost (GETSTATS, implemented):**
 - Handler runs inline in the EP0 callback — one `CyU3PGpifGetSMState()`
   call, three `memcpy` operations, and one I2C register read (~50 µs)
-- 20-byte EP0 response per poll; at 10 polls/sec: 200 bytes/sec
+- 26-byte EP0 response per poll; at 10 polls/sec: 260 bytes/sec
 - Counters reuse the existing `glCounter[20]` array — zero additional BSS
 
 **Projected cost (DIAGFX3 extension, if implemented):**

--- a/docs/gpif-and-recovery.md
+++ b/docs/gpif-and-recovery.md
@@ -2,6 +2,7 @@
 title: GPIF & Recovery
 nav_order: 6
 permalink: /gpif-and-recovery/
+description: Cypress FX3 GPIF II state machine for the RX888mk2 - states, transitions, soft-stop via FW_TRG deassert, force-stop fallback, streaming-wedge watchdog.
 ---
 
 # GPIF State Machine and Recovery

--- a/docs/gpif-and-recovery.md
+++ b/docs/gpif-and-recovery.md
@@ -4,11 +4,18 @@ nav_order: 6
 permalink: /gpif-and-recovery/
 ---
 
-# GPIF State Machine and Recovery Architecture
+# GPIF State Machine and Recovery
 
 This document describes the GPIF II state machine design, the soft-stop
-mechanism, and the layered recovery architecture that keeps the RX888mk2
-firmware streaming reliably under adverse conditions.
+mechanism, and the GPIF-level recovery actions (force-stop fallback and
+the streaming-wedge watchdog) that keep the streaming pipeline alive.
+
+It covers the GPIF slice of the recovery story only.  The firmware also
+has higher-level recovery layers (EP0 vendor-handler liveness check with
+device reset, and an FX3 hardware-watchdog catastrophic backstop) that
+sit above the GPIF watchdog and handle wedges the GPIF layer cannot
+see.  For the full cascade across all layers, see
+[README §Firmware Robustness](https://github.com/ringof/rx888-firmware#firmware-robustness).
 
 For general firmware architecture, see [architecture.md](architecture.md).
 For clock-loss detection specifics, see [wedge_detection.md](wedge_detection.md).
@@ -295,130 +302,104 @@ it always did.
 
 ---
 
-## Layered recovery architecture
+## GPIF-level recovery
 
-The firmware implements four layers of recovery, from lightest to
-heaviest.  Each layer handles failures that the layer above cannot.
+This section covers only the GPIF-specific recovery mechanisms.  The
+firmware's full recovery story spans multiple layers — GPIF watchdog,
+EP0 vendor-handler liveness check, and FX3 hardware watchdog — see
+[README §Firmware Robustness](https://github.com/ringof/rx888-firmware#firmware-robustness)
+for the cascade across all layers.
 
-### Layer 1: Soft-stop (STOPFX3 / watchdog)
+### Soft-stop and force-stop
 
-**Trigger**: Host issues STOPFX3, or watchdog detects DMA stall.
+The GPIF state machine has two stop paths.
 
-**Action**: Deassert FW_TRG → SM exits to IDLE → disable GPIF →
-reset DMA → flush USB endpoint.
+**Soft-stop** is the routine path.  The firmware deasserts `FW_TRG`,
+waits ~1 ms for the SM to exit to IDLE via the `!FW_TRG` transitions
+described above, then disables GPIF cleanly.  Used by both STOPFX3
+and the streaming watchdog.  Leaves no residual state because the SM
+is in IDLE when disabled.  Latency dominated by the 1 ms sleep, not
+the SM transition (which completes in 3 clocks ≈ 47 ns at 64 MHz).
 
-**Latency**: ~1 ms (dominated by `CyU3PThreadSleep`, not the SM).
+**Force-stop** is the fallback.  If soft-stop times out — SM did not
+reach IDLE after the wait — the firmware calls
+`CyU3PGpifDisable(CyTrue)`, which kills the GPIF hardware
+unconditionally.  This wipes configuration and requires
+`CyU3PGpifLoad` to restart.  Triggered when the external clock is
+not running or PLL is unlocked: with no clock edges, the SM cannot
+advance to IDLE regardless of `FW_TRG`.
 
-**What it fixes**: Normal stop/start cycles, backpressure-induced
-stalls, routine watchdog recoveries.  Leaves no residual state
-because the SM is in IDLE when disabled.
+Both paths are followed by a DMA channel reset and a USB endpoint
+flush before any restart attempt.
 
-### Layer 2: Force-stop fallback
+### Streaming-wedge watchdog
 
-**Trigger**: Soft-stop fails — SM did not reach IDLE after FW_TRG
-deassert (dead clock, PLL unlock, unexpected SM state).
+The main thread polls `glDMACount` every 100 ms while streaming.  If
+the count fails to advance for three consecutive polls (~300 ms) and
+the GPIF SM is in a BUSY or WAIT state (`TH0_BUSY` (5), `TH1_BUSY` (7),
+`TH1_WAIT` (8), or `TH0_WAIT` (9)), the pipeline is wedged and the
+watchdog runs a recovery:
 
-**Action**: `CyU3PGpifDisable(CyTrue)` — kills GPIF hardware
-unconditionally.  Wipes configuration; requires `CyU3PGpifLoad` to
-restart.
+1. Soft-stop (with force-stop fallback).
+2. DMA channel reset and USB endpoint flush.
+3. If the Si5351 reports the ADC clock enabled and PLL locked,
+   re-arm the DMA channel, reload GPIF, restart the SM, and
+   reassert `FW_TRG`.  Otherwise wait — soft-stop requires clock
+   edges, and a re-arm with no clock just re-wedges.
 
-**Latency**: ~1 ms.
+Total latency: ~300 ms (detection) + ~1 ms (recovery).
 
-**What it fixes**: Hardware faults where the external clock is not
-running and the SM cannot advance to IDLE.  This is the last resort
-before requiring host intervention.
+The watchdog fixes DMA pipeline wedges caused by transient USB
+backpressure, xHCI endpoint ring issues, or momentary clock glitches.
+It does not fix EP0-handler hangs or main-thread death — those are
+handled by the higher cascade layers (see the README).
 
-### Layer 3: Watchdog recovery
+### Recovery cap
 
-**Trigger**: `glDMACount` stops advancing for 3 consecutive 100 ms
-polls while the SM is in a BUSY or WAIT state (states 5, 7, 8, 9).
-
-**Action**: Soft-stop (with force-stop fallback) → DMA channel
-reset → USB endpoint flush → if clock is healthy: DMA re-arm →
-GPIF reload and restart → reassert FW_TRG.
-
-**Latency**: ~300 ms (stall detection) + ~1 ms (recovery).
-
-**Recovery cap**: Limited to `WDG_MAX_RECOVERY_DEFAULT` (5)
+The streaming watchdog is capped at `WDG_MAX_RECOVERY_DEFAULT` (5)
 consecutive recoveries per session.  After the cap is reached, the
 watchdog stops retrying and waits for the host to issue STARTFX3.
 The cap prevents unbounded recovery loops when the host is not
 draining data (application crash, abandoned stream).  The cap
-counter resets on STARTFX3 and STOPFX3.
-
-**What it fixes**: DMA pipeline wedges caused by transient USB
-backpressure, xHCI endpoint ring issues, or momentary clock glitches.
-
-### Layer 4: Host restart
-
-**Trigger**: Application decides to restart (timeout on bulk read,
-GETSTATS shows stale dma_count, or scheduled reconfiguration).
-
-**Action**: STOPFX3 → STARTFX3.  Resets all pipeline state: DMA
-channels, GPIF configuration (full reload), counters, and watchdog
-recovery cap.
-
-**Latency**: ~100 ms (including USB control transfer round-trips).
-
-**What it fixes**: Everything that the watchdog cannot — including
-the state after the watchdog cap is reached, firmware-level
-configuration errors, and frequency changes that require ADC clock
-reprogramming.
-
-### Recovery hierarchy summary
-
-| Layer | Trigger | Action | Latency | Leaves debris? |
-|-------|---------|--------|---------|----------------|
-| Soft-stop | STOPFX3 / watchdog | FW_TRG deassert → IDLE → disable | ~1 ms | No |
-| Force-stop | Soft-stop failure | `CyU3PGpifDisable(CyTrue)` | ~1 ms | Possible |
-| Watchdog | DMA stall 300 ms | Tear down + rebuild pipeline | ~300 ms | No (uses soft-stop) |
-| Host restart | Application decision | STOPFX3 + STARTFX3 | ~100 ms | No (full reset) |
-
-### What cannot be recovered
-
-- **USB disconnect**: The FX3 re-enumerates; the host must re-open
-  the device.
-- **Firmware crash**: The FX3 falls back to DFU bootloader mode
-  (PID 0x00F3); the host must re-upload firmware.
-- **Hardware fault**: Dead ADC, broken clock crystal, or damaged
-  FX3.  No software recovery is possible.
+counter resets on STARTFX3 and STOPFX3.  The cap value is
+runtime-configurable via SETARGFX3 `WDG_MAX_RECOV` (wIndex 14); 0
+disables the cap entirely.
 
 ---
 
-## Soak test evidence
+## Soft-stop landing: before/after evidence
 
-The recovery architecture was validated with a randomized soak test
-(`fx3_cmd soak`) that exercises 39 scenarios including streaming,
-stop/start cycling, clock manipulation, I2C under load, EP0 stress,
-and deliberate fault injection.
+The soft-stop mechanism described above was introduced after
+soak-testing revealed that force-stop-only behavior cascaded between
+scenarios: force-stop debris from one cycle stalled the next.  The
+following comparison (both runs at seed 20, on the firmware revisions
+before and after the soft-stop change) is preserved here as the
+GPIF-specific evidence for that landing.  For current
+firmware-wide soak metrics, see the README and `CHANGELOG.md`.
 
-### Before soft-stop (force-stop only)
-
-688 cycles, seed 20:
+### Before soft-stop (force-stop only) — 688 cycles, seed 20
 
 - 239 streaming faults (watchdog recoveries)
-- 4 dma_count_monotonic failures (31% failure rate)
+- 4 `dma_count_monotonic` failures (31% failure rate)
 - All failures show GPIF state 255 (SM killed mid-transaction)
 - Cascading recovery pattern: force-stop debris from one scenario
   stalls the next
 
-### After soft-stop
-
-534 cycles, seed 20:
+### After soft-stop — 534 cycles, seed 20
 
 - 0 device crashes (534/534 health checks passed)
-- 0 stop_start_cycle failures (51/51)
-- 0 dma_count_monotonic failures (10/10)
-- 0 dma_count_reset failures (11/11)
-- 0 sustained_stream failures (8/8, 99% throughput)
+- 0 `stop_start_cycle` failures (51/51)
+- 0 `dma_count_monotonic` failures (10/10)
+- 0 `dma_count_reset` failures (11/11)
+- 0 `sustained_stream` failures (8/8, 99% throughput)
 - GPIF state consistently 1 (IDLE) at stop, never 255
 - 37 of 39 scenarios at 100% pass rate
 
 The two remaining failure scenarios (`abandoned_stream`,
-`watchdog_cap_observe`) were caused by a test harness bug that
+`watchdog_cap_observe`) were caused by a test-harness bug that
 disabled the watchdog recovery cap, not a firmware issue.
 
-### Running the soak test
+### Reproducing the comparison
 
 The soak test requires an RX888mk2 connected via USB with firmware
 loaded.  Build the test tools, then run:
@@ -428,15 +409,11 @@ cd tests && make
 sudo ./fx3_cmd soak 1 20
 ```
 
-Arguments: `soak [hours] [seed] [max_scenarios]`.  The default is 1
-hour with a random seed.  `seed 20` is the baseline used for the
-before/after comparison above.  The test runs 39 weighted-random
-scenarios in a loop, with a health check (TESTFX3 + GETSTATS) between
-each one.  Press Ctrl-C for an early summary.
-
-The 1-hour soak with seed 20 passed with **zero device crashes** and
-**100% health-check pass rate** across 500+ cycles on the current
-firmware.
+Arguments: `soak [hours] [seed] [max_scenarios]`.  `seed 20` is the
+baseline used for the comparison above.  The test runs a
+weighted-random rotation of scenarios in a loop, with a health
+check (TESTFX3 + GETSTATS) between each one.  Press Ctrl-C for an
+early summary.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 title: Home
 layout: home
 nav_order: 1
+description: Open-source Cypress FX3 USB controller firmware for the RX888 mk2 direct-sampling SDR.  Vendor-command protocol, GPIF state machine, ka9q-radio compatibility.
 ---
 
 # RX888mk2 Firmware

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,81 @@ documentation.  For source and issue tracking, see the
   [wedge detection]({{ '/wedge_detection/' | relative_url }}),
   [license analysis]({{ '/LICENSE_ANALYSIS/' | relative_url }}).
 
+## If you're about to write FX3 firmware for an SDR
+
+This section is for developers who landed here Googling specific FX3
+problems — start with the prior art before reinventing it.  Each
+question below maps to a documented, working solution in this
+firmware.
+
+### Recovering from an FX3 DMA wedge mid-stream
+
+If the ADC clock stops or USB backpressure stalls the DMA pipeline,
+the GPIF state machine wedges in a BUSY/WAIT state and `glDMACount`
+stops advancing.  The firmware's streaming watchdog polls every
+100 ms, soft-stops the SM (with force-stop fallback), resets DMA,
+flushes the bulk endpoint, and restarts streaming if the Si5351 PLL
+is still locked.  Bounded by a per-session recovery cap.  Details:
+[GPIF state machine and recovery]({{ '/gpif-and-recovery/' | relative_url }})
+and [wedge detection]({{ '/wedge_detection/' | relative_url }}).
+
+### Detecting a stuck EP0 vendor-handler and resetting the device
+
+If a USB vendor request hangs inside an SDK call, the device looks
+alive on the bus but no EP0 traffic returns and the host has no
+recovery path short of unplugging the device.  The firmware tracks
+EP0-handler enter/exit events from the main loop and invokes
+`CyU3PDeviceReset()` if a handler runs longer than the configured
+timeout.  See the recovery cascade in
+[README §Firmware Robustness](https://github.com/ringof/rx888-firmware#firmware-robustness)
+and the implementation in `SDDC_FX3/health.c`.
+
+### Petting the FX3 hardware watchdog without false positives
+
+Naive `CyU3PSysWatchDogClear()` from the main loop pets the WD as
+long as the timer scheduler is running — which doesn't catch
+main-thread death.  This firmware uses Infineon KB223337's
+documented pattern: a ThreadX timer callback pets the HWDT, but
+only when the main-loop heartbeat counter has advanced since its
+last check.  If the main thread spins forever, the heartbeat
+freezes and HWDT fires within the configured period.  See
+[README §Firmware Robustness](https://github.com/ringof/rx888-firmware#firmware-robustness).
+
+### Querying Si5351 CLK0 state without a host-cache flag
+
+If a host programs the Si5351 directly via I2C and the firmware's
+streaming preflight only consults an internal "did STARTADC happen"
+flag, the preflight rejects valid streaming setups.  This firmware
+reads the Si5351 CLK0_CONTROL register (bit 7 = CLK0_PDN) over I2C
+inside `si5351_clk0_enabled()` so `GpifPreflightCheck()` sees the
+chip's real state.  See
+[USB API reference]({{ '/api/' | relative_url }}) (`GETSTATS` bytes
+24-25, exposing the raw register byte plus the chip-query boolean)
+and [ka9q-radio compat audit]({{ '/ka9q-compat-audit/' | relative_url }})
+§8 for the failure mode this fixes.
+
+### Integrating ka9q-radio's `rx888.so` plugin
+
+ka9q-radio drives the device via standard USB vendor commands; the
+audit confirms compatibility with this firmware's vendor-command
+set and documents the few cosmetic mismatches (TUNERSTDBY STALLs on
+the HF path, LED bit positions).  No host-side patches are
+required as of v0.1.0.  See
+[ka9q-radio compat audit]({{ '/ka9q-compat-audit/' | relative_url }})
+and [host application compatibility]({{ '/compatibility/' | relative_url }}).
+
+### Exposing FX3 firmware counters to a host application
+
+`GETSTATS` (`0xB3`) is a 26-byte EP0 vendor read that returns DMA
+buffer count, GPIF state, PIB error counts, I2C failure counts,
+streaming-fault count, Si5351 PLL status, a boot counter (for
+mid-test reset detection), and Si5351 CLK0 raw register plus the
+chip-query boolean.  Drop-in pattern for any FX3 firmware that
+needs a host-readable health view.  See
+[USB API reference]({{ '/api/' | relative_url }}) (GETSTATS section)
+and the [diagnostics side-channel]({{ '/diagnostics_side_channel/' | relative_url }})
+design notes.
+
 ## Scope and limitations
 
 This firmware operates the **HF direct-sampling path only**.  The R828D VHF

--- a/docs/ka9q-compat-audit.md
+++ b/docs/ka9q-compat-audit.md
@@ -6,7 +6,7 @@ permalink: /ka9q-compat-audit/
 
 # ka9q-radio ↔ SDDC_FX3 Compatibility Audit
 
-Status: **initial findings, container-side patches landed**
+Status: **container-side patches retired in v0.1.0** — the only host-side workaround (patch 03) is no longer needed; see §8 for the firmware fix.
 
 This document captures a static compatibility audit of ka9q-radio's
 `rx888.so` plugin against the SDDC_FX3 firmware in this repository.
@@ -159,7 +159,19 @@ PLL programming (`docs/architecture.md` §"Frequency setting
 algorithm"); ka9q also sleeps ~1 s host-side around PLL config
 (`rx888.c:400`). Total ~2 s; slower than necessary but not broken.
 
-### 8. Show-stopper: missing `STARTADC` before `STARTFX3` *(ka9q-side)*
+### 8. Show-stopper: missing `STARTADC` before `STARTFX3` *(resolved firmware-side in v0.1.0)*
+
+> **Resolved in firmware** (commit
+> [`13b2091`](https://github.com/ringof/rx888-firmware/commit/13b2091),
+> released in **v0.1.0**).  `si5351_clk0_enabled()` now reads CLK0_CONTROL
+> register 16 bit 7 over I2C instead of consulting a stale
+> `glAdcClockEnabled` host-cache flag.  `GpifPreflightCheck()` therefore
+> sees the live chip state, ka9q-radio's direct Si5351 programming
+> path passes preflight without `STARTADC`, and patch 03 has been
+> retired (kept in-tree as `.patch.disabled` for archaeology — see
+> `docker/ka9q-radio/patches/README.md`).  The analysis below is
+> preserved as a record of the original failure mode.
+
 
 ka9q programs the Si5351 directly via raw `I2CWFX3` writes
 (`rx888.c:331`, `rx888.c:340`) and intentionally never calls

--- a/docs/ka9q-compat-audit.md
+++ b/docs/ka9q-compat-audit.md
@@ -2,6 +2,7 @@
 title: ka9q-radio compat audit
 nav_order: 10
 permalink: /ka9q-compat-audit/
+description: Static audit of ka9q-radio against the RX888mk2 FX3 firmware - vendor-command compatibility, STARTADC/STARTFX3 ordering (fixed in v0.1.0), VHF/HF coverage.
 ---
 
 # ka9q-radio ↔ SDDC_FX3 Compatibility Audit

--- a/docs/ka9q-compat-audit.md
+++ b/docs/ka9q-compat-audit.md
@@ -45,7 +45,7 @@ function so the analysis stays valid across line shifts.
 |---|---|---|---|
 | STARTFX3 | 0xAA | ✅ | |
 | STOPFX3 | 0xAB | ✅ | |
-| TESTFX3 | 0xAC | ✅ | |
+| TESTFX3 | 0xAC | ✅ | Defined in `rx888.h` but never sent by ka9q — see §9. |
 | GPIOFX3 | 0xAD | ✅ | LED bit positions differ — see §4. |
 | I2CWFX3 | 0xAE | ✅ | |
 | I2CRFX3 | 0xAF | ✅ | |
@@ -218,6 +218,21 @@ through commit `13b2091`, at which point the firmware-side fix in
 The disabled patch file remains in-tree as
 `03-startadc-before-startfx3.patch.disabled` for archaeology; see
 `docker/ka9q-radio/patches/README.md`.
+
+### 9. TESTFX3 (0xAC) defined but not exercised *(no host coordination needed)*
+
+ka9q's `rx888.h` defines `TESTFX3 = 0xAC` in the `FX3Command` enum,
+but `rx888.c` contains zero occurrences of `TESTFX3`, `0xAC`, or
+the word "version".  The plugin never issues the `TESTFX3` request,
+never reads the device's model/version word, and has no version
+comparison logic.
+
+Implication: SDDC firmware's `FIRMWARE_VER_MAJOR` /
+`FIRMWARE_VER_MINOR` can change between firmware releases (e.g. the
+v0.1.0 bump from 2.2 to 2.3) without any host-side coordination
+from ka9q.  The compatibility-matrix row for `TESTFX3` above
+reflects that it is *supported* by the firmware (returns a 4-byte
+response), not that it is *sent* by ka9q.
 
 ## Container-side requirements (no patches needed)
 

--- a/docs/ka9q-compat-audit.md
+++ b/docs/ka9q-compat-audit.md
@@ -10,7 +10,8 @@ Status: **container-side patches retired in v0.1.0** — the only host-side work
 
 This document captures a static compatibility audit of ka9q-radio's
 `rx888.so` plugin against the SDDC_FX3 firmware in this repository.
-It is intentionally narrow: every claim cites a specific source line.
+Every claim cites a specific source file; behavior is named by
+function so the analysis stays valid across line shifts.
 
 ## Reproducer
 
@@ -50,7 +51,7 @@ It is intentionally narrow: every claim cites a specific source line.
 | I2CRFX3 | 0xAF | ✅ | |
 | RESETFX3 | 0xB1 | ✅ | |
 | STARTADC | 0xB2 | ✅ | Both sides sleep ~1 s; see §7. |
-| TUNERINIT | 0xB4 | ❌ STALL | Only inside `#if 0` (`rx888.c:950–980`). |
+| TUNERINIT | 0xB4 | ❌ STALL | Only inside `#if 0` in `rx888.c`. |
 | TUNERTUNE | 0xB5 | ❌ STALL | Only inside `#if 0`. |
 | SETARGFX3 wIndex 1 (R82XX_ATTENUATOR) | 0xB6 | ❌ STALL | VHF only — see §3. |
 | SETARGFX3 wIndex 2 (R82XX_VGA)        | 0xB6 | ❌ STALL | VHF only. |
@@ -67,16 +68,11 @@ SDDC firmware `docs/architecture.md` §"Command table" and
 
 ### 1. `sleep(1)` after firmware upload *(ka9q-side, documented; no patch)*
 
-`src/rx888.c:700`:
-
-```c
-sleep(1); // how long should this be?
-```
-
-After firmware upload, ka9q sleeps once for one second, then performs
-a **single** scan for `0x04b4:0x00f1` and returns "Error or device
-could not be found" if absent (`rx888.c:803–804`). The author's own
-comment flags the value as a guess.
+After firmware upload, `rx888_usb_init()` in ka9q's `src/rx888.c`
+sleeps once for one second, then performs a **single** scan for
+`0x04b4:0x00f1` and returns "Error or device could not be found" if
+absent.  The author's own comment on the `sleep(1)` flags the value
+as a guess.
 
 Original misdiagnosis: this was *thought* to be the cause of the
 container's "Error or device could not be found" failure.  It was
@@ -97,21 +93,21 @@ last firmware byte is acked (per `usbmon`), and the upstream
 `sleep(1)` + single rescan succeeds reliably.  Verified working on
 the project's reference hardware.
 
-A polling-with-timeout pattern in `rx888.c:700` would be more robust
-on pathologically slow hosts, but it is not required for SDDC
-streaming to work, so we do not patch it — the cost of a
-not-strictly-necessary upstream ask outweighs the benefit on
-hypothetical hardware.
+A polling-with-timeout pattern in place of the fixed `sleep(1)`
+would be more robust on pathologically slow hosts, but it is not
+required for SDDC streaming to work, so we do not patch it — the
+cost of a not-strictly-necessary upstream ask outweighs the benefit
+on hypothetical hardware.
 
 ### 2. TUNERSTDBY (0xB8) on the HF path *(ka9q-side, cosmetic; no patch)*
 
-`src/rx888.c:943` (`rx888_set_hf_mode`) and `src/rx888.c:1003`
-(`rx888_start_rx`) both fire `command_send(...,TUNERSTDBY,0)`. SDDC
-firmware removed all R82xx commands (`docs/LICENSE_ANALYSIS.md`),
-so 0xB8 returns a clean USB STALL via the firmware's default
-handler.  ka9q's `command_send` ignores the return value, so
-streaming is unaffected and init proceeds normally.  The only effect
-is bus-level noise: two STALLed control transfers per session.
+ka9q's `rx888_set_hf_mode()` and `rx888_start_rx()` both fire
+`command_send(...,TUNERSTDBY,0)`.  SDDC firmware removed all R82xx
+commands (see `docs/LICENSE_ANALYSIS.md`), so 0xB8 returns a clean
+USB STALL via the firmware's default handler.  ka9q's `command_send`
+ignores the return value, so streaming is unaffected and init
+proceeds normally.  The only effect is bus-level noise: two STALLed
+control transfers per session.
 
 We do not patch this either — purely cosmetic, would not change
 observable behavior, and removing two unconditional command sends
@@ -120,16 +116,16 @@ patch most maintainers will reject as not-their-bug.
 
 ### 3. R82xx VHF path *(deferred, out of scope)*
 
-`rx888.c:921` (`R82XX_ATTENUATOR`), `rx888.c:937` (`R82XX_VGA`),
-`rx888.c:972–973` (TUNERINIT, TUNERTUNE — inside `#if 0`).
-
-VHF will not work end-to-end because SDDC removed every R82xx code
-path; ka9q itself flags VHF as broken (`rx888.c:11`,
-"VHF tuner does not work yet -- KA9Q, 17 Aug 2024"). HF is unaffected.
+ka9q's `rx888.c` issues `R82XX_ATTENUATOR` and `R82XX_VGA` on the
+VHF init path, plus `TUNERINIT` and `TUNERTUNE` inside an `#if 0`
+block.  VHF will not work end-to-end because SDDC removed every
+R82xx code path; ka9q itself flags VHF as broken in a top-of-file
+comment ("VHF tuner does not work yet -- KA9Q, 17 Aug 2024").
+HF is unaffected.
 
 ### 4. GPIO LED bit-position mismatch *(cosmetic)*
 
-| Bit | ka9q (`rx888.h:131–133`) | SDDC firmware (`docs/architecture.md` §"GPIOFX3 bitmask protocol") |
+| Bit | ka9q (`rx888.h`) | SDDC firmware (`docs/architecture.md` §"GPIOFX3 bitmask protocol") |
 |-----|-------|----------|
 | 10  | `LED_YELLOW` | unused |
 | 11  | `LED_RED`    | `LED_BLUE` |
@@ -141,23 +137,28 @@ could converge to the other's mapping; deferred.
 
 ### 5. SuperSpeed gate *(host topology, not SDDC)*
 
-`src/rx888.c:769` rejects anything below `LIBUSB_SPEED_SUPER`
-silently inside the scan loop, then exits with the same
-"device could not be found" string. If the device is plugged into a
-USB-2 port or behind a hub that downgrades, ka9q reports
-identical-looking output. Worth flagging in user docs.
+ka9q's `rx888.c` rejects anything below `LIBUSB_SPEED_SUPER`
+silently inside its device scan loop, then exits with the same
+"device could not be found" string.  If the device is plugged into
+a USB-2 port or behind a hub that downgrades, ka9q reports
+identical-looking output.  Worth flagging in user docs.
 
 ### 6. PID `0x00F1` matches ✅
 
-ka9q's `Loaded_product_id = 0x00f1` (`rx888.c:36`) matches SDDC
-firmware's advertised PID (`docs/architecture.md` §687–692).
+ka9q's `Loaded_product_id = 0x00f1` in `rx888.c` matches SDDC
+firmware's advertised PID (see `docs/architecture.md` §"USB
+descriptors").
 
 ### 7. STARTADC settling
 
-SDDC firmware sleeps 1000 ms inside the `STARTADC` handler after
-PLL programming (`docs/architecture.md` §"Frequency setting
-algorithm"); ka9q also sleeps ~1 s host-side around PLL config
-(`rx888.c:400`). Total ~2 s; slower than necessary but not broken.
+SDDC firmware's `STARTADC` handler polls `si5351_pll_locked()` for
+up to ~100 ms after programming the PLL, returning as soon as PLL A
+reports lock (see `docs/architecture.md` §"Clock synthesis").  ka9q
+also sleeps ~1 s host-side around its direct Si5351 programming in
+`rx888_set_samprate()`.  The firmware-side wait used to be a fixed
+~1 s sleep before commit `13b2091`; together with ka9q's host-side
+sleep the round trip was ~2 s.  As of v0.1.0 the firmware contributes
+≤100 ms and the round trip is dominated by ka9q's host-side wait.
 
 ### 8. Show-stopper: missing `STARTADC` before `STARTFX3` *(resolved firmware-side in v0.1.0)*
 
@@ -173,45 +174,50 @@ algorithm"); ka9q also sleeps ~1 s host-side around PLL config
 > preserved as a record of the original failure mode.
 
 
-ka9q programs the Si5351 directly via raw `I2CWFX3` writes
-(`rx888.c:331`, `rx888.c:340`) and intentionally never calls
-`STARTADC` (the `docker/ka9q-radio/README.md` originally documented
-this as a feature: "bypasses firmware STARTADC").  Against stock
-RX888 firmware where `STARTADC` only does Si5351 setup, this works.
+ka9q programs the Si5351 directly via raw `I2CWFX3` writes (in
+`rx888_set_samprate()`) and intentionally never calls `STARTADC`
+(the `docker/ka9q-radio/README.md` originally documented this as a
+feature: "bypasses firmware STARTADC").  Against stock RX888
+firmware where `STARTADC` only does Si5351 setup, this works.
 
-SDDC firmware tracks ADC-clock readiness via a separate global flag
-`glAdcClockEnabled` (`SDDC_FX3/driver/Si5351.c:55`), set `CyTrue`
-*only* inside `si5351aSetFrequencyA(freq>0)`
-(`SDDC_FX3/driver/Si5351.c:250`), called *only* from the `STARTADC`
-handler (`SDDC_FX3/USBHandler.c:219`).  The `STARTFX3` handler then
-runs `GpifPreflightCheck()`
-(`SDDC_FX3/StartStopApplication.c:99`) before starting the GPIF
-state machine:
+Pre-v0.1.0 SDDC firmware tracked ADC-clock readiness via a separate
+global flag `glAdcClockEnabled` in `SDDC_FX3/driver/Si5351.c`, set
+`CyTrue` *only* inside `si5351aSetFrequencyA(freq>0)`, called *only*
+from the `STARTADC` handler in `SDDC_FX3/USBHandler.c`.  The
+`STARTFX3` handler then ran `GpifPreflightCheck()` in
+`SDDC_FX3/StartStopApplication.c` before starting the GPIF state
+machine:
 
     if (!si5351_clk0_enabled())  return CyFalse;  // glAdcClockEnabled
     if (!si5351_pll_locked())    return CyFalse;
 
-`si5351_clk0_enabled()` returns the bare flag
-(`SDDC_FX3/driver/Si5351.c:174`) — it does not query the chip — so
-even though ka9q has correctly programmed Si5351 via I2C and the
-PLL is physically locked, the flag remains `CyFalse`.  `STARTFX3`
-stalls EP0 (`SDDC_FX3/USBHandler.c:333`), GPIF never starts, no
-bulk data flows, and radiod times out:
+`si5351_clk0_enabled()` returned the bare flag — it did not query
+the chip — so even though ka9q had correctly programmed Si5351 via
+I2C and the PLL was physically locked, the flag remained `CyFalse`.
+`STARTFX3` stalled EP0, GPIF never started, no bulk data flowed,
+and radiod timed out:
 
     rx888 running
     No rx888 data for 5 seconds, quitting
 
-By comparison, `rx888_stream` (the test harness) sends the commands
-in the order SDDC requires (`rx888_stream.c:1185 / 1193`):
+By comparison, `rx888_stream` (the test harness) sent the commands
+in the order SDDC required:
 
     DAT31_ATT → AD8340_VGA → STARTADC(samprate) → STARTFX3 → ...
 
-Fix: send `STARTADC` with the configured sample rate just before
-`STARTFX3` in `rx888_start_rx()`.  STARTADC reprograms Si5351 to
-the same frequency ka9q already wrote (harmless duplicate), sets
+The original container-side fix was to insert
+`command_send(...,STARTADC,samprate)` before `STARTFX3` in
+`rx888_start_rx()`: STARTADC reprograms Si5351 to the same
+frequency ka9q already wrote (harmless duplicate), sets
 `glAdcClockEnabled = CyTrue`, polls PLL lock (already locked,
-returns immediately), and `STARTFX3`'s preflight then passes.  See
-`docker/ka9q-radio/patches/03-startadc-before-startfx3.patch`.
+returns immediately), and `STARTFX3`'s preflight then passes.
+
+That fix shipped as `docker/ka9q-radio/patches/03-startadc-before-startfx3.patch`
+through commit `13b2091`, at which point the firmware-side fix in
+§8's resolution banner above made the host-side patch unnecessary.
+The disabled patch file remains in-tree as
+`03-startadc-before-startfx3.patch.disabled` for archaeology; see
+`docker/ka9q-radio/patches/README.md`.
 
 ## Container-side requirements (no patches needed)
 
@@ -223,30 +229,25 @@ with "Error or device could not be found".  See §1 for the analysis.
 
 ## Patches applied in this container
 
-The patch set is intentionally minimal — one patch, for the one
-incompatibility that has no host-side or container-side workaround:
-
-`docker/ka9q-radio/patches/03-startadc-before-startfx3.patch` —
-insert `command_send(...,STARTADC,samprate)` before `STARTFX3` in
-`rx888_start_rx` so SDDC's `GpifPreflightCheck()` passes (§8).
+**None as of v0.1.0.**  The only patch that ever shipped (patch 03 —
+inserting `STARTADC` before `STARTFX3`) was retired once the firmware
+began reporting Si5351 CLK0 state truthfully; see §8.  The disabled
+patch is preserved in-tree as
+`docker/ka9q-radio/patches/03-startadc-before-startfx3.patch.disabled`
+and is skipped by the Dockerfile's `*.patch` glob.  See
+`docker/ka9q-radio/patches/README.md` for the historical record.
 
 The findings in §1 (`sleep(1)`) and §2 (TUNERSTDBY) are documented
 above but do **not** become container patches: §1 has a working
 container-level workaround (the udev mount), and §2 is purely
-cosmetic.  Carrying patches we don't strictly need would dilute the
-single ask we make of the upstream maintainer.
-
-The Dockerfile applies the patch with `git apply --whitespace=nowarn`
-against the pinned SHA.  When upstream ka9q-radio merges an
-equivalent fix, bump `KA9Q_RADIO_SHA` and drop the patch.
+cosmetic.  Carrying patches we don't strictly need would dilute any
+future ask we make of the upstream maintainer.
 
 ## Open work
 
-- Confirm container streams continuously (>1 minute) with patch 03
-  applied and the udev mount present.  Initial confirmation:
-  container reaches "rx888 running" and starts streaming; long-run
-  stability not yet measured.
-- Submit patch 03 upstream to `ka9q/ka9q-radio` as the focused
-  STARTADC/STARTFX3 ordering fix.
+- Long-run streaming stability against the v0.1.0 container is not
+  yet measured.  Initial confirmation in v0.1.0 prep: container
+  reaches "rx888 running" and starts streaming without host-side
+  patches.
 - File issues for VHF support (firmware-side R82xx return) and the
   LED bit-position decision; both are non-blocking for HF receive.

--- a/docs/vendor-protocol-plan.md
+++ b/docs/vendor-protocol-plan.md
@@ -6,9 +6,15 @@ permalink: /vendor-protocol-plan/
 
 # Vendor Protocol Evolution Plan
 
-**Status:** approved for execution
-**Branch:** TBD (likely a successor to `claude/fix-docker-build-path-qLngV` once #91 is merged)
-**Trigger:** ka9q-radio Docker test harness surfaced a hidden coupling between `STARTADC` and `STARTFX3` (audit §8).  Fixing only the bug misses the larger lesson; this plan addresses both.
+**Status as of v0.1.0:** Commits 1 and 2 shipped (firmware Si5351
+chip-query and the docker patch-03 retirement, both via PR #122).
+Commits 3 and 4 — `GETCAPABILITIES` / `GETSTATE` vendor commands and
+the recommended-sequence documentation — remain unwritten.  The plan
+text below is preserved as the design rationale for the remaining
+work; the Commit 1 and Commit 2 subsections are marked **DONE
+(v0.1.0)** with shipping-commit pointers.
+
+**Trigger:** ka9q-radio Docker test harness surfaced a hidden coupling between `STARTADC` and `STARTFX3` (audit §8).  Fixing only the bug missed the larger lesson; this plan addresses both.
 
 ## For the executing Claude instance
 

--- a/docs/vendor-protocol-plan.md
+++ b/docs/vendor-protocol-plan.md
@@ -62,7 +62,16 @@ This principle binds **every** firmware change in this plan.  Each commit must i
 
 Each commit is independently mergeable.  Order matters only for documentation cross-references.
 
-### Commit 1 — `fix(Si5351): query CLK0_PDN directly instead of trusting STARTADC flag`
+### Commit 1 — `fix(Si5351): query CLK0_PDN directly instead of trusting STARTADC flag` ✅ DONE (v0.1.0)
+
+> **Shipped** in commit
+> [`13b2091`](https://github.com/ringof/rx888-firmware/commit/13b2091)
+> via PR #122, released in **v0.1.0**.  The companion docker change
+> (Commit 2 below — retire patch 03) shipped in the same PR.  Scope
+> was slightly extended in flight: `GETSTATS` was widened from 24 to 26
+> bytes to expose CLK0_CONTROL raw byte ([24]) and the boolean
+> chip-query result ([25]) for diagnostics.  Subsections preserved
+> below as historical record.
 
 **Scope:** `SDDC_FX3/driver/Si5351.c` only (~20 lines edited / removed).
 
@@ -80,7 +89,19 @@ Each commit is independently mergeable.  Order matters only for documentation cr
 
 **Risk:** low.  `I2cTransfer()` is a proven path (used by `si5351_pll_locked`).  Reading register 16 is non-destructive.
 
-### Commit 2 — `refactor(docker): drop ka9q patch 03; firmware fix supersedes it`
+### Commit 2 — `refactor(docker): drop ka9q patch 03; firmware fix supersedes it` ✅ DONE (v0.1.0)
+
+> **Shipped** in PR #122 (commit
+> [`60af0b7`](https://github.com/ringof/rx888-firmware/commit/60af0b7)),
+> released in **v0.1.0**.  Implementation diverged slightly from the
+> plan: rather than deleting the patch outright, it was renamed to
+> `03-startadc-before-startfx3.patch.disabled` so the Dockerfile glob
+> skips it but the historical record stays in-tree.  The
+> Dockerfile loop was also hardened with a POSIX empty-glob guard
+> (commit
+> [`0993747`](https://github.com/ringof/rx888-firmware/commit/0993747))
+> after a Codex review flagged the original `shopt -s nullglob`
+> approach as bash-only.
 
 **Scope:** test-harness side only.
 

--- a/docs/vendor-protocol-plan.md
+++ b/docs/vendor-protocol-plan.md
@@ -55,6 +55,7 @@ Concretely, the firmware must guarantee:
 - Malformed payloads (wrong length, out-of-range values) are rejected at the EP0 boundary; they do not corrupt internal state.
 - The escape hatches `RESETFX3` and `STOPFX3` always work, including from a wedged GPIF state.
 - Host-side `libusb_reset_device()` — and ultimately a USB unplug/replug — always brings the device back to bootloader (`04b4:00f3`) or to the loaded baseline (`04b4:00f1` with idle GPIF).
+- **Unknown-opcode contract (feature-detection guarantee).**  Any vendor request byte not currently implemented must STALL cleanly without advancing any internal state.  Clients (e.g. `librx888`) may probe-then-issue to detect optional commands without risking a wedge.  Validated by the soak/fuzz harness, which deliberately injects unallocated opcodes (`0xFF` today; reserved-range bytes once commit 3 lands).
 
 This principle binds **every** firmware change in this plan.  Each commit must include a soak/fuzz test (or pointer to one) demonstrating that the change does not create a new wedge mode.
 
@@ -123,7 +124,7 @@ Each commit is independently mergeable.  Order matters only for documentation cr
 - `GETCAPABILITIES` (0xBB) — returns a JSON object describing firmware version, build SHA, supported-commands list, sample-rate min/max, GPIO bit map (so the LED ambiguity in audit §4 becomes queryable), ADC bit width.  JSON keeps the schema flexible — fields can be added without breaking parsers.  Example:
 
   ```json
-  {"version":"0.0.1","build":"f78cff9","commands":["STARTFX3","STOPFX3","STARTADC","GPIOFX3","I2CWFX3","I2CRFX3","SETARGFX3","RESETFX3","READINFODEBUG","GETSTATS","GETCAPABILITIES","GETSTATE"],"sample_rate_hz":{"min":2000000,"max":129600000},"gpio_bits":{"DITHER":0,"RANDOM":1,"VHF_EN":2,"LED_BLUE":11},"adc_bits":16}
+  {"schema_version":1,"version":"0.0.1","build":"f78cff9","commands":["STARTFX3","STOPFX3","STARTADC","GPIOFX3","I2CWFX3","I2CRFX3","SETARGFX3","RESETFX3","READINFODEBUG","GETSTATS","GETCAPABILITIES","GETSTATE"],"sample_rate_hz":{"min":2000000,"max":129600000},"gpio_bits":{"DITHER":0,"RANDOM":1,"VHF_EN":2,"LED_BLUE":11},"adc_bits":16}
   ```
 
   Returned over EP0 in chunks if it exceeds `CYFX_SDRAPP_MAX_EP0LEN`; host issues repeat reads until done.  Length capped (e.g. 1024 bytes) so this never wedges.
@@ -131,10 +132,20 @@ Each commit is independently mergeable.  Order matters only for documentation cr
 - `GETSTATE` (0xBC) — returns a smaller JSON object with current SM state, current Si5351 frequency (read from chip), current GPIO bits, last vendor-command error code:
 
   ```json
-  {"sm_state":"IDLE","si5351_clk0_hz":64800000,"gpio":3,"last_error":0,"streaming":false}
+  {"schema_version":1,"sm_state":"IDLE","si5351_clk0_hz":64800000,"gpio":3,"last_error":0,"streaming":false}
   ```
 
 **Why JSON over fixed binary:** schema flexibility (new fields don't break old hosts), introspection by hand (`curl`-style debugging via `usbcontrol` or similar), easier integration with web-based tooling (ka9q-web, future telemetry).  Cost is parser size — small in C with a string-matching scanner, and the firmware only needs to *emit*, not parse.
+
+**Future compatibility (librx888 and other downstream clients).**  The following invariants are guarantees, not coincidences, and must be preserved as new commands and fields are added:
+
+- **`schema_version` is the negotiation hatch.**  Major-version bumps signal a breaking change (field removed, type changed, semantics altered).  Minor-version bumps signal additive growth and must not break clients that ignore unknown fields.  Today both `GETCAPABILITIES` and `GETSTATE` ship at `"schema_version": 1`.
+- **JSON growth contract.**  Future firmware revisions may *add* fields to either response; clients must ignore unknown fields rather than rejecting the document.  Removing a field, or changing its type or semantics, requires a major-version bump.
+- **`commands` is the feature-detection surface.**  The string array must enumerate every vendor command the firmware will accept.  Any future opcode added to the firmware must be appended to this list in the same revision; existing entries are stable.  Clients perform feature detection by string lookup rather than by hardcoded opcode tables.
+- **Opcode reservations.**  To leave room for the typed-setter expansion that downstream clients (e.g. `librx888`) will need without colliding with one-off additions, the following ranges are reserved:
+  - **`0xD0–0xDF` — typed configuration setters.**  Reserved for future single-concern, typed-argument setters (e.g. `SET_SAMPRATE`, `SET_RF_ATTEN`).  Do not allocate these bytes for ad-hoc additions; pull from `0xB7–0xB9` or `0xBD–0xCD` instead.
+  - **`0xE0–0xEF` — typed query expansion.**  Reserved for future structured query commands beyond `GETCAPABILITIES`/`GETSTATE`.
+  - These reservations are advisory only; no firmware code today enforces them.  A future commit may add an enum range guard.
 
 **Recoverability check:** both commands are read-only.  Truncated reads or aborted transfers leave the firmware in EP0 idle.  Bounded length cap means no buffer-overflow surface.
 
@@ -266,6 +277,7 @@ static int build_capabilities_json(char *buf, int max)
 {
     return snprintf(buf, max,
         "{"
+          "\"schema_version\":1,"
           "\"version\":\"%s\","
           "\"build\":\"%s\","
           "\"commands\":[\"STARTFX3\",\"STOPFX3\",\"STARTADC\",\"GPIOFX3\","

--- a/docs/vendor-protocol-plan.md
+++ b/docs/vendor-protocol-plan.md
@@ -2,6 +2,7 @@
 title: Vendor protocol plan
 nav_order: 9
 permalink: /vendor-protocol-plan/
+description: Plan for the next-generation FX3 vendor-command protocol on the RX888mk2 - GETCAPABILITIES, GETSTATE, separation of concerns, recoverability invariant.
 ---
 
 # Vendor Protocol Evolution Plan

--- a/docs/wedge_detection.md
+++ b/docs/wedge_detection.md
@@ -17,6 +17,17 @@ This document explains why the wedge happens, what detection mechanisms
 the FX3 SDK provides, and how the firmware now implements a
 stop-and-wait recovery.
 
+This doc covers the GPIF (streaming) slice of wedge detection only.
+The broader recovery cascade in the firmware also handles EP0
+vendor-handler hangs (Level 4 device reset) and main-thread death
+(Level 5 FX3 HWDT) — see
+[README §Firmware Robustness](https://github.com/ringof/rx888-firmware#firmware-robustness)
+for the canonical cross-layer view.  The GPIF streaming watchdog
+described below is currently independent of `SDDC_FX3/health.c` and
+lives in `SDDC_FX3/RunApplication.c`; migrating it behind
+`health_evaluate()` / `health_recover(WEDGED_STREAMING)` is tracked
+as issue #115.
+
 ---
 
 ## What happens when the ADC clock disappears
@@ -94,12 +105,12 @@ These catch the **secondary failure** (DMA congestion after the host
 stops reading), not the clock loss itself.
 
 **Implementation:** The callback is registered in `StartApplication()`
-(`StartStopApplication.c:167`):
+(`SDDC_FX3/StartStopApplication.c`):
 ```c
 CyU3PPibRegisterCallback(PibErrorCallback, CYU3P_PIB_INTR_ERROR);
 ```
 
-The callback body (`StartStopApplication.c:41-49`) increments
+The callback body (`PibErrorCallback`, same file) increments
 `glCounter[0]`, saves the error argument in `glLastPibArg`, and posts
 the event to the `glEventAvailable` queue where `MsgParsing()` prints
 it to the debug console as `"PIB error 0x..."`.
@@ -132,9 +143,10 @@ detects:
 At 100 ms polling interval, even the slowest rate produces ~48 buffers
 per interval.  A zero-delta is an unambiguous stall indicator.
 
-**Implementation:** The GPIF watchdog in `RunApplication.c:216-295`
-uses `glDMACount` delta == 0 as the first trigger condition.  The
-count must also be > 0 (streaming has started) to avoid false triggers
+**Implementation:** The GPIF watchdog in
+`SDDC_FX3/RunApplication.c`'s `ApplicationThread()` main loop uses
+`glDMACount` delta == 0 as the first trigger condition.  The count
+must also be > 0 (streaming has started) to avoid false triggers
 on idle devices.
 
 ### 3. GPIF state machine polling
@@ -180,15 +192,15 @@ symptom (DMA stall).
 **Implementation:** Used in two places:
 
 1. **Pre-flight check** (`GpifPreflightCheck()` in
-   `StartStopApplication.c:89-100`): called before every `STARTFX3`.
+   `SDDC_FX3/StartStopApplication.c`): called before every `STARTFX3`.
    Verifies CLK0 is enabled (`si5351_clk0_enabled()`) and PLL A is
    locked (`si5351_pll_locked()`).  If either fails, `STARTFX3` is
    rejected with an EP0 STALL.
 
-2. **Watchdog recovery** (`RunApplication.c:253-268`): after tearing
-   down the pipeline, the watchdog reads PLL lock status.  If locked,
-   it auto-restarts streaming.  If unlocked, it leaves the pipeline
-   stopped and waits for the host to reconfigure.
+2. **Watchdog recovery** (in `RunApplication.c`'s watchdog block):
+   after tearing down the pipeline, the watchdog reads PLL lock
+   status.  If locked, it auto-restarts streaming.  If unlocked, it
+   leaves the pipeline stopped and waits for the host to reconfigure.
 
 3. **GETSTATS** (`USBHandler.c`): the Si5351 status register is
    sampled at read time and returned as byte 19 of the GETSTATS
@@ -239,7 +251,7 @@ device crashes with this architecture.
 
 ## Implemented recovery
 
-### GPIF watchdog (`RunApplication.c:216-295`)
+### GPIF watchdog (in `SDDC_FX3/RunApplication.c`)
 
 The application thread runs a watchdog inside the existing 100 ms
 polling loop.  The detection and recovery sequence is:
@@ -272,7 +284,7 @@ graph TD
     WAIT --> DONE2["Increment glCounter 2<br/>Reset stall counter + DMA count<br/>Log RECOVERY WAIT"]
 ```
 
-### Pre-flight check (`StartStopApplication.c:89-100`)
+### Pre-flight check (in `SDDC_FX3/StartStopApplication.c`)
 
 Every `STARTFX3` vendor command runs `GpifPreflightCheck()` before
 touching the GPIF:
@@ -308,17 +320,36 @@ The host is informed of watchdog recovery events through:
 
 ## Implementation status
 
-| Priority | Change | Status | Detection latency |
-|----------|--------|--------|-------------------|
-| **1** | PIB error callback: log + post event to app thread | **Done** (`StartStopApplication.c:41-49,167`) | ~ms (interrupt-driven) |
-| **2** | `glDMACount` delta check in watchdog | **Done** (`RunApplication.c:221`) | 100-300 ms (polling) |
-| **3** | Si5351 PLL lock check before STARTFX3 (preflight) | **Done** (`StartStopApplication.c:89-100`) | N/A (pre-flight) |
-| **4** | GPIF state polling in watchdog (BUSY/WAIT detection) | **Done** (`RunApplication.c:226-228`) | 100-300 ms (polling) |
-| **5** | Si5351 PLL lock check during recovery | **Done** (`RunApplication.c:262`) | 300 ms (after 3 stall polls) |
-| **5b** | Watchdog recovery cap (`glWdgMaxRecovery`) | **Done** (`RunApplication.c:235-240`) | N/A (limit, not detection) |
-| **6** | Add `!FW_TRG → IDLE` transitions to GPIF SM | **Done** (`SDDC_GPIF.h`, see [gpif-and-recovery.md](gpif-and-recovery.md)) | <1 clock (~16 ns) |
+| Priority | Change | Lives in | Detection latency |
+|----------|--------|----------|-------------------|
+| **1** | PIB error callback: log + post event to app thread | `SDDC_FX3/StartStopApplication.c` (`PibErrorCallback`) | ~ms (interrupt-driven) |
+| **2** | `glDMACount` delta check in watchdog | `SDDC_FX3/RunApplication.c` (watchdog block) | 100-300 ms (polling) |
+| **3** | Si5351 PLL lock check before STARTFX3 (preflight) | `SDDC_FX3/StartStopApplication.c` (`GpifPreflightCheck`) | N/A (pre-flight) |
+| **4** | GPIF state polling in watchdog (BUSY/WAIT detection) | `SDDC_FX3/RunApplication.c` (watchdog block) | 100-300 ms (polling) |
+| **5** | Si5351 PLL lock check during recovery | `SDDC_FX3/RunApplication.c` (watchdog recovery) | 300 ms (after 3 stall polls) |
+| **5b** | Watchdog recovery cap (`glWdgMaxRecovery`) | `SDDC_FX3/RunApplication.c` (watchdog cap counter) | N/A (limit, not detection) |
+| **6** | Add `!FW_TRG → IDLE` transitions to GPIF SM | `SDDC_FX3/SDDC_GPIF.h`; see [gpif-and-recovery.md](gpif-and-recovery.md) | <1 clock (~16 ns) |
 
 All priorities are implemented.  The silent wedge is now a
 detected-and-recovered condition.  Priority 6 (soft-stop via
-`CyU3PGpifDisable(CyFalse)`) was validated with 500+ soak test
-cycles at zero device crashes.
+`CyU3PGpifDisable(CyFalse)`) was validated by a 500+ cycle soak run
+at zero device crashes — see
+[gpif-and-recovery.md §Soft-stop landing: before/after evidence](gpif-and-recovery.md#soft-stop-landing-beforeafter-evidence)
+for the comparison numbers.  Current firmware-wide soak status lives
+in the [README](https://github.com/ringof/rx888-firmware#firmware-robustness)
+and `CHANGELOG.md`.
+
+### Relationship to the broader recovery cascade
+
+The streaming watchdog described above is the **Level 1** of the
+firmware's five-level recovery cascade.  Levels 4 (EP0 vendor-handler
+wedge → device reset) and 5 (main-thread death → FX3 hardware
+watchdog) are implemented in `SDDC_FX3/health.c` and cover wedge
+classes the GPIF watchdog cannot see.  See
+[README §Firmware Robustness](https://github.com/ringof/rx888-firmware#firmware-robustness)
+for the cross-layer view.
+
+Today the GPIF watchdog is **independent** of `health.c` — it lives
+in `RunApplication.c`'s main loop and owns its own state.  Migrating
+it behind the `health_evaluate` / `health_recover(WEDGED_STREAMING)`
+interface is tracked as issue #115.

--- a/docs/wedge_detection.md
+++ b/docs/wedge_detection.md
@@ -2,6 +2,7 @@
 title: Wedge detection
 nav_order: 8
 permalink: /wedge_detection/
+description: Detecting and recovering from FX3 DMA wedges caused by Si5351 PLL unlock or clock loss mid-stream - PIB callbacks, DMA count polling, pre-flight checks.
 ---
 
 # GPIF Clock Loss Detection and Wedge Recovery

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,32 +60,80 @@ to bootloader first if needed).  Both use `rx888_stream` from the
 
 ### Automated test commands
 
-Each prints `PASS`/`FAIL` and exits 0/1:
+Each prints `PASS`/`FAIL` and exits 0/1.  Scenarios cluster into a
+few categories — a representative sample below; the canonical full
+list lives in the `cmd_table[]` at the top of
+`tests/fx3_cmd.c`, or run `./fx3_cmd debug` and type `!help` for
+the same list interactively.
+
+**EP0 / vendor-command boundaries:**
 
 ```
-./fx3_cmd ep0_overflow                  # wLength > 64 must STALL (#6)
-./fx3_cmd oob_brequest                  # bRequest=0xCC bounds check (#21)
-./fx3_cmd oob_setarg                    # SETARGFX3 wIndex=0xFFFF (#20)
-./fx3_cmd console_fill                  # 35 chars to 32-byte buffer (#13)
-./fx3_cmd debug_race                    # 50 rapid debug I/O cycles (#8)
-./fx3_cmd debug_poll                    # debug console "?" command (#26)
-./fx3_cmd pib_overflow                  # PIB error detection (#10)
-./fx3_cmd stack_check                   # stack watermark > 25% (#12)
+./fx3_cmd ep0_overflow                  # wLength > 64 must STALL
+./fx3_cmd oob_brequest                  # unknown bRequest STALLs
+./fx3_cmd oob_setarg                    # SETARGFX3 wIndex=0xFFFF
+./fx3_cmd ep0_stall_recovery            # EP0 stall then immediate use
+./fx3_cmd vendor_rqt_wrap               # counter wraparound at 256
+./fx3_cmd stale_vendor_codes            # dead-zone bRequest values
+./fx3_cmd setarg_gap_index              # near-miss SETARGFX3 wIndex
+./fx3_cmd ep0_hammer                    # 500 rapid EP0s during stream
+```
+
+**GPIF / streaming:**
+
+```
+./fx3_cmd stop_gpif_state               # GPIF SM lands in IDLE
+./fx3_cmd stop_start_cycle              # cycle STOP+START with data verify
+./fx3_cmd gpif_soft_stop                # soft-stop reaches IDLE (needs new waveform)
+./fx3_cmd stop_under_backpressure       # STOP while DMA buffers full
+./fx3_cmd sustained_stream              # continuous streaming check
+./fx3_cmd dma_count_monotonic           # DMA counter monotonic during stream
+./fx3_cmd dma_count_reset               # DMA counter reset on STARTFX3
+./fx3_cmd data_sanity                   # bulk-data corruption check
+```
+
+**Recovery validation:**
+
+```
+./fx3_cmd wedge_recovery                # DMA wedge + STOP+START recovery
+./fx3_cmd watchdog_cap_observe          # observe watchdog fault plateau
+./fx3_cmd watchdog_cap_restart          # restart after watchdog cap
+./fx3_cmd clock_pull                    # pull clock mid-stream, verify recovery
+./fx3_cmd test_health_recovery          # HANGFX3 + Level-4 EP0 reset round-trip
+./fx3_cmd test_main_recovery            # HANGMAIN + Level-5 HWDT round-trip
+./fx3_cmd abandoned_stream              # simulate host crash (no STOPFX3)
+```
+
+**Si5351 / ADC clock:**
+
+```
+./fx3_cmd pll_preflight                 # STARTFX3 rejected without PLL lock
+./fx3_cmd clk0_chip_query               # STARTFX3 STALLs after CLK0 power-down via I2CWFX3
+./fx3_cmd freq_hop                      # rapid ADC frequency hopping
+./fx3_cmd adc_freq_extremes             # edge ADC frequencies
+```
+
+**Diagnostics counters:**
+
+```
+./fx3_cmd stats                         # snapshot full GETSTATS
 ./fx3_cmd stats_i2c                     # I2C failure counter
 ./fx3_cmd stats_pib                     # PIB error counter
 ./fx3_cmd stats_pll                     # Si5351 PLL lock status
-./fx3_cmd stop_gpif_state               # GPIF SM stops correctly
-./fx3_cmd stop_start_cycle              # 5x STOP+START with data verify
-./fx3_cmd pll_preflight                 # STARTFX3 rejected without clock
-./fx3_cmd wedge_recovery                # DMA wedge + STOP+START recovery
-./fx3_cmd clock_pull                    # pull clock mid-stream, verify recovery
-./fx3_cmd freq_hop                      # rapid ADC frequency hopping
-./fx3_cmd ep0_stall_recovery            # EP0 stall then immediate use
-./fx3_cmd double_stop                   # back-to-back STOPFX3
-./fx3_cmd double_start                  # back-to-back STARTFX3
+./fx3_cmd stack_check                   # stack watermark > 25%
+```
+
+**Debug / I/O paths:**
+
+```
+./fx3_cmd console_fill                  # console-buffer fill behavior
+./fx3_cmd debug_race                    # rapid debug I/O cycles
+./fx3_cmd debug_poll                    # debug console "?" command
+./fx3_cmd readinfodebug_flood           # debug buffer flood without drain
+./fx3_cmd debug_cmd_while_stream        # debug command during streaming
 ./fx3_cmd i2c_under_load                # I2C read while streaming
-./fx3_cmd sustained_stream              # 30s continuous streaming check
-./fx3_cmd abandoned_stream              # simulate host crash (no STOPFX3)
+./fx3_cmd i2c_write_bad_addr            # I2C write NACK counter
+./fx3_cmd i2c_multibyte                 # multi-byte I2C round-trip
 ```
 
 ### Consumer-failure tests
@@ -187,6 +235,11 @@ shutdown with a full summary.
 
 # 8-hour overnight run
 ./fx3_cmd soak 8
+
+# Bias the rotation: surface a specific scenario faster by cranking
+# its weight (--weight / -w NAME=N, repeatable, max 32 overrides).
+./fx3_cmd soak 1 42 --weight test_health_recovery=20 \
+                    --weight test_main_recovery=20
 ```
 
 Output includes a status line every 10 cycles and a final table:
@@ -224,10 +277,17 @@ Handles firmware upload and device probe before invoking `fx3_cmd soak`.
                        loaded firmware handles stress correctly.
 ```
 
+Per-scenario weight overrides (`--weight NAME=N`) are not forwarded
+by this wrapper — for biased rotations, invoke `./fx3_cmd soak`
+directly.
+
 ## fw_test.sh -- Automated TAP Test Suite
 
-Runs the full test suite (30 tests, 33 with streaming) in TAP format.
-Handles firmware upload automatically via `rx888_stream`.
+Runs an end-to-end firmware test suite in TAP format: firmware
+upload, device probe, all stale-command / OOB / debug-path / GPIF
+checks, GETSTATS counter validation, watchdog and stop/start
+cycles, and (optionally) a live streaming capture.  Handles
+firmware upload automatically via `rx888_stream`.
 
 ```
 ./fw_test.sh --firmware ../SDDC_FX3/SDDC_FX3.img
@@ -252,13 +312,20 @@ Handles firmware upload automatically via `rx888_stream`.
 ### Example output
 
 ```
-1..30
+1..N
 ok 1 - firmware upload (PID 0x00F1)
 ok 2 - device probe (hwconfig=0x04)
 ok 3 - GPIO set LED_BLUE
 ...
-ok 30 - GETSTATS PIB counter > 0
+ok N - stream: non-zero data present
+#
+# N passed, 0 failed out of N tests
 ```
+
+`N` is set by the `PLANNED` counter at the top of `fw_test.sh` and
+varies as scenarios are added.  Each block in the script prints
+`ok` or `not ok` for one numbered TAP entry; the streaming test at
+the end contributes a few additional sub-assertions.
 
 ## File map
 


### PR DESCRIPTION
## Summary

Release-prep for **v0.1.0**.  Now twelve commits — the two pre-existing release commits plus the full v0.1.0 docs audit punch list (issue #114 follow-up), the CI optimization that landed alongside, and the working rule "no file:line callouts in docs" applied repo-wide.

| Commit | What |
|---|---|
| `94b5e89` | Bump `FIRMWARE_VER_MINOR` 2 → 3 in `SDDC_FX3/protocol.h`; matching update to `docs/api.md` "Reference firmware version" line. |
| `2382034` | Doc updates: README pointer to the GitHub Pages site, `ka9q-compat-audit.md` reframed (patch 03 retired in v0.1.0), `vendor-protocol-plan.md` Commits 1 & 2 marked DONE, new `CHANGELOG.md` (Keep-a-Changelog format) with the `[0.1.0]` entry. |
| `f7b699b` | **Audit #1** — archive completed plans `PLAN_RECOVERY.md` (shipped PR #112; deferred §5 item now tracked as #115) and `PLAN_GH_PAGES.md` (shipped PR #121) to `docs/archive/` with status headers.  Update the five remaining references in `README.md` and `SDDC_FX3/health.{c,h}`. |
| `bb79f61` | **Audit #2** — reframe `docs/gpif-and-recovery.md` as GPIF-only.  The "Layered recovery architecture" four-layer model contradicted the README's five-level cascade; resolution is to make the README canonical for the cascade and narrow this doc to GPIF-specific recovery (soft-stop, force-stop, streaming-wedge watchdog). |
| `fdcced8` | **Audit #3** — sync GETSTATS wire layout (20 → 26 bytes) across `docs/diagnostics_side_channel.md`, `docs/architecture.md`, and `SDDC_FX3/docs/debugging.md`.  `docs/api.md` was already in sync (06af0b7); these three lagged.  Adds rows for offsets 20-23 (`boot_count`), 24 (Si5351 CLK0_CONTROL), 25 (`clk0_result`). |
| `4f20f29` | **Audit #4** — refresh `docs/architecture.md`.  Recovery section gains a "Wider recovery cascade" paragraph (health.c, EP0 Level 4, HWDT Level 5, HANGFX3/HANGMAIN, boot_count).  Vendor-command table fixes wLength (STARTFX3/STOPFX3/RESETFX3 4 B → 0 B; READINFODEBUG 100 B → ≤ 64 B) and adds HANGFX3 / HANGMAIN test-only rows.  Clock-synthesis §: replace stale "sleeps 1000 ms" with the actual `si5351_pll_locked()` polling (≤ 100 ms).  Source-file reference table: **drop the Lines column entirely** (per-file line counts are stale-prone by construction).  Add `health.c` / `health.h` rows. |
| `ce6e7a9` | **Audit #5** — finish the `docs/ka9q-compat-audit.md` v0.1.0 reframe (§7 STARTADC settling, §8 closing, "Patches applied" rewritten, "Open work" refreshed).  Apply the **no-line-callouts working rule** for the first time: strip every external `file:line` callout in the prose; each citation is now by file and function name only. |
| `0e1a126` | Follow-up to ce6e7a9 — add §9 to `ka9q-compat-audit.md` documenting that ka9q-radio never exercises `TESTFX3` (defined in `rx888.h` but `rx888.c` does not send it; firmware version can bump without host coordination).  Matrix row for TESTFX3 clarified.  Same line-callout strip applied to `docker/ka9q-radio/patches/README.md`. |
| `57de54d` | **Audit #6** — refresh `tests/README.md` against current `fx3_cmd.c` and `fw_test.sh`.  The 24-of-~48-scenarios enumerated list is replaced with six categorized representative blocks plus a pointer at the canonical source (`cmd_table[]` in `fx3_cmd.c`, or `!help` in the interactive console).  Document the `--weight NAME=N` soak option.  Drop the hard "30 tests, 33 with streaming" count (same rot trap as the Lines column). |
| `e6cf23d` | **CI optimization** — add `paths-ignore` to `.github/workflows/build.yml`'s `push` and `pull_request` triggers so doc-only changes don't burn ~2 min of runner time on the firmware/host build.  The Pages workflow already self-filters. |
| `8f53c60` | **Audit #7** — scope `docs/wedge_detection.md` to GPIF (streaming) wedge detection only.  Add cross-references at the top and in a new "Relationship to the broader recovery cascade" section pointing at README §Firmware Robustness for the cross-layer view.  Note that the streaming watchdog is currently independent of `health.c` (migration tracked as issue #115).  Apply the no-line-callouts rule: eight callouts and two section-heading line ranges stripped; implementation-status table's stale "Status (`file.c:NNN`)" column replaced by a "Lives in" column naming the file and the named block. |
| `cd3ba5f` | **Audit #8 + #9** — drop the empty `## [0.1.0-rc0]` heading from `CHANGELOG.md` (no rc0 tag was ever pushed; the body was a placeholder).  Lift `docs/vendor-protocol-plan.md`'s per-commit DONE status to a top-of-doc "Status as of v0.1.0" paragraph; clean the stale `claude/fix-docker-build-path-qLngV` branch hint. |

## Working rules that emerged mid-PR

1. **No file:line callouts in docs** — line numbers go stale instantly; refer to source files and named functions/blocks only.  Applied retroactively to every doc this PR touched.  Working rule going forward.
2. **No file-length stat columns in source-file maps** — same rot class as line callouts.  The Lines column in `architecture.md`'s source-file table is gone; describe what each file does, not how big it is.

## Why bump firmware to 2.3

PR #122 changed the `GETSTATS` reply length from 24 → 26 bytes (added Si5351 CLK0_CONTROL raw byte at offset 24 and the chip-query boolean at offset 25).  Hosts can detect the new layout by reading the firmware version via `TESTFX3` — although `docs/ka9q-compat-audit.md` §9 (new in this PR) confirms ka9q-radio specifically does not exercise that, so no host coordination needed for that consumer.  Backwards-compatible: hosts that still request `wLength=24` keep working — firmware returns only the requested prefix.

## Why this is safe

- No protocol/ABI change beyond a single byte in the version word.
- No firmware behavior change beyond the version constant.
- All twelve other commits are documentation or CI.

## Validation

After flashing the rebuilt firmware:

```
./fx3_cmd testfx3
```

should report firmware version **2.3** (high byte 2, low byte 3 of the `glFWconfig` word).  Existing test suite and host applications continue to work without modification.

## Test plan

- [x] `make -C SDDC_FX3 clean all` produces `SDDC_FX3.img` (regression).
- [x] After flashing, `./fx3_cmd testfx3` reports firmware version 2.3.
- [x] `./fx3_cmd soak 0.1 0 0` is clean against the rebuilt firmware (regression).
- [ ] GitHub Pages site rebuilds after merge and shows "Reference firmware version: **2.3**" on the API page.
- [ ] Spot-check the rebuilt Pages site: `/gpif-and-recovery/` no longer claims a four-layer model; `/wedge_detection/` opens with the GPIF scoping paragraph and points at README §Firmware Robustness; the GETSTATS layout on `/api/`, `/diagnostics_side_channel/`, and the architecture command table all agree on 26 bytes; the architecture source-file map has no Lines column; `PLAN_RECOVERY.md` and `PLAN_GH_PAGES.md` no longer appear at the repo root.
- [ ] On a docs-only follow-up PR to this branch, the `build` workflow does not run (paths-ignore working).
- [ ] After merge, push tag `v0.1.0` to publish the first stable release via `.github/workflows/release.yml`.

## Tagging plan (post-merge)

Once this lands on `main`:

```
git checkout main
git pull
git tag -a v0.1.0 -m "v0.1.0: Si5351 chip-query, ka9q-radio compatibility, recovery cascade, Pages docs"
git push origin v0.1.0
```

The release workflow triggers on `push:tags` and publishes `SDDC_FX3.img` + host tools as release assets.  Stable tag (no `-rc` suffix) means asset names drop the suffix.

## Branch-protection note on the CI change

If `build / firmware` or `build / host-tests` is configured as a required status check in this repo's main-branch protection settings, the `paths-ignore` added in `e6cf23d` will cause docs-only PRs to sit waiting for a check that no longer runs.  Two fixes:

1. **Repo-side (simpler)**: in branch protection for main, drop these from "required" or rely on GitHub's behavior that treats a non-running check as not-required.
2. **Workflow-side**: add a stub job with the inverse path filter that exits 0, so the check name resolves either way.

Not gating this PR — the repo-side fix is preferred.

## Note on branch name

Originally intended as `release/v0.1.0-prep` per offline discussion; the local rename was created but the git proxy returned HTTP 503 on new-ref creates.  Falling back to publishing the PR on the already-pushed `claude/v0.1.0-prep` ref to avoid losing progress.  Cosmetic only.

## Related

- Builds on #122 (Si5351 chip-query).
- Builds on #121 (GitHub Pages site).
- Closes the v0.1.0 release-prep work items from `docs/vendor-protocol-plan.md` Commits 1 and 2.
- **Fully consumes the punch list from issue #114** (the v0.1.0 docs audit).
- Tracks #115 (deferred streaming-watchdog migration into `health_recover()`) as a follow-up; mentioned by several reframed docs as the open work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVupZ7HarDbqepkbhY3xrj)_