### PR TITLE
refactor(health): move Level-1 streaming watchdog into health.c (#115)

### DIFF
--- a/SDDC_FX3/RunApplication.c
+++ b/SDDC_FX3/RunApplication.c
@@ -32,8 +32,6 @@ extern void ParseCommand(void);
 // Declare external data
 extern const char* EventName[];
 extern uint32_t glDMACount;
-extern uint32_t glCounter[20];
-extern CyU3PDmaMultiChannel glMultiChHandleSlFifoPtoU;
 
 // Global data owned by this module
 CyBool_t glIsApplnActive = CyFalse;     // Set true once device is enumerated
@@ -42,9 +40,6 @@ uint32_t glEventAvailableQueue[16] __attribute__ ((aligned (32)));// Queue for u
 uint32_t glQevent __attribute__ ((aligned (32)));
 CyU3PThread glThreadHandle[APP_THREADS];		// Handles to my Application Threads
 void *glStackPtr[APP_THREADS];				// Stack allocated to each thread
-
-uint8_t glWdgMaxRecovery = WDG_MAX_RECOVERY_DEFAULT;
-uint8_t glWdgRecoveryCount = 0;
 
 uint8_t glHWconfig = NORADIO;       // Hardware config type BBRF103
 uint16_t glFWconfig = (FIRMWARE_VER_MAJOR << 8) | FIRMWARE_VER_MINOR;    // Firmware rc1 ver 1.02
@@ -247,108 +242,10 @@ void ApplicationThread ( uint32_t input)
 					if (nline++ == 0) DebugPrint(4, "\r\n"); //first line
 					MsgParsing(glQevent);
 				}
-				/* GPIF watchdog: detect and recover from DMA stalls.
-				 * If glDMACount hasn't advanced for 3 consecutive 100ms
-				 * polls while the GPIF SM is in a BUSY/WAIT state, the
-				 * streaming pipeline is wedged.  Tear it down and rebuild. */
-				if (glIsApplnActive)
-				{
-					static uint32_t prevDMACount = 0;
-					static uint8_t  stallCount = 0;
-
-					uint32_t curDMA = glDMACount;
-					if (curDMA == prevDMACount && curDMA > 0)
-					{
-						uint8_t gpifState = 0xFF;
-						CyU3PGpifGetSMState(&gpifState);
-
-						if (gpifState == GPIF_TH0_BUSY || gpifState == GPIF_TH1_BUSY ||
-						    gpifState == GPIF_TH1_WAIT || gpifState == GPIF_TH0_WAIT)
-						{
-							stallCount++;
-							DebugPrint(4, "\r\nWDG: stall %d/3 SM=%d DMA=%u",
-								stallCount, gpifState, curDMA);
-							if (stallCount >= 3)  /* 300ms in BUSY/WAIT */
-							{
-								/* Check recovery cap before attempting */
-								if (glWdgMaxRecovery > 0 &&
-								    glWdgRecoveryCount >= glWdgMaxRecovery)
-								{
-									DebugPrint(4, "\r\nWDG: recovery limit (%d), waiting for STARTFX3",
-										glWdgMaxRecovery);
-									stallCount = 0;
-								}
-								else
-								{
-									CyU3PReturnStatus_t rc_reset, rc_flush;
-									CyU3PReturnStatus_t rc_xfer = 0, rc_sm = 0;
-									CyBool_t hw_ok;
-
-									glWdgRecoveryCount++;
-									DebugPrint(4, "\r\nWDG: === RECOVERY START === SM=%d DMA=%u recov=%d/%d",
-										gpifState, curDMA, glWdgRecoveryCount, glWdgMaxRecovery);
-									/* Soft-stop: deassert FW_TRG so the SM exits
-									 * to IDLE via !FW_TRG transitions.
-									 * REQUIRES updated SDDC_GPIF.h waveform with
-									 * !FW_TRG exits on TH0_RD, TH0_WAIT, TH1_WAIT.
-									 *
-									 * Caveat: soft-stop needs the external clock
-									 * to advance the SM.  If the Si5351 is dead
-									 * or PLL unlocked, the SM can't transition
-									 * and soft-stop fails — fall back to force. */
-									CyU3PGpifControlSWInput(CyFalse);
-									CyU3PThreadSleep(1);
-									{
-										uint8_t smState = 0xFF;
-										CyU3PGpifGetSMState(&smState);
-										if (smState == GPIF_IDLE) {
-											CyU3PGpifDisable(CyFalse);
-										} else {
-											DebugPrint(4, "\r\nWDG: soft-stop fail SM=%d, forcing", smState);
-											CyU3PGpifDisable(CyTrue);
-										}
-									}
-
-									rc_reset = CyU3PDmaMultiChannelReset(&glMultiChHandleSlFifoPtoU);
-									rc_flush = CyU3PUsbFlushEp(CY_FX_EP_CONSUMER);
-
-									hw_ok = si5351_clk0_enabled() && si5351_pll_locked();
-									if (hw_ok)
-									{
-										rc_xfer = CyU3PDmaMultiChannelSetXfer(
-											&glMultiChHandleSlFifoPtoU, FIFO_DMA_RX_SIZE, 0);
-										rc_sm = CyU3PGpifSMStart(0, 0);
-										CyU3PGpifControlSWInput(CyTrue);
-									}
-									glCounter[2]++;  /* streaming fault counter —
-									                  * GETSTATS [15..18]; also incremented
-									                  * by EP_UNDERRUN in USBHandler.c */
-									DebugPrint(4, "\r\nWDG: === RECOVERY %s === rst=%d flush=%d xfer=%d sm=%d",
-										hw_ok ? "DONE" : "WAIT",
-										rc_reset, rc_flush, rc_xfer, rc_sm);
-									stallCount = 0;
-									prevDMACount = 0;
-									glDMACount = 0;
-								}
-							}
-						}
-						else
-						{
-							if (stallCount > 0)
-								DebugPrint(4, "\r\nWDG: stall cleared SM=%d (was %d/3)",
-									gpifState, stallCount);
-							stallCount = 0;
-						}
-					}
-					else
-					{
-						if (stallCount > 0)
-							DebugPrint(4, "\r\nWDG: DMA resumed (%u->%u), stall cleared",
-								prevDMACount, curDMA);
-						stallCount = 0;
-						prevDMACount = curDMA;
-					}
-				}
+				/* Streaming watchdog (Level 1) now runs via health_tick()
+				 * above: health_evaluate() detects the DMA stall and
+				 * health_recover(HEALTH_WEDGED_STREAMING) rebuilds the
+				 * pipeline.  Migrated out of this loop in issue #115. */
 
 #ifndef _DEBUG_USB_  // second count in serial debug
 				if (glDMACount > 7812)

--- a/SDDC_FX3/USBHandler.c
+++ b/SDDC_FX3/USBHandler.c
@@ -46,8 +46,6 @@ extern uint8_t glBufDebug[MAXLEN_D_USB];
 extern uint32_t glCounter[20];
 extern uint16_t glLastPibArg;
 extern uint32_t glDMACount;
-extern uint8_t glWdgMaxRecovery;
-extern uint8_t glWdgRecoveryCount;
 
 
 
@@ -355,7 +353,7 @@ CyFxSlFifoApplnUSBSetupCB (
 							isHandled = CyTrue;
 							break;
 						case WDG_MAX_RECOV:
-							glWdgMaxRecovery = (uint8_t)(wValue & 0xFF);
+							health_set_max_recovery((uint8_t)(wValue & 0xFF));
 							glVendorRqtCnt++;
 							isHandled = CyTrue;
 							break;
@@ -416,7 +414,7 @@ CyFxSlFifoApplnUSBSetupCB (
 				 * what is actually wrong — the symptom it masked was an
 				 * xHCI endpoint-ring issue fixed host-side by clear_halt. */
 				glDMACount = 0;  /* reset so watchdog doesn't false-positive during GPIF bring-up */
-				glWdgRecoveryCount = 0;  /* new session — reset recovery cap */
+				health_reset_recovery_count();  /* new session — reset recovery cap */
 				apiRetStatus = CyU3PDmaMultiChannelSetXfer (&glMultiChHandleSlFifoPtoU, FIFO_DMA_RX_SIZE, 0);
 				if (apiRetStatus == CY_U3P_SUCCESS) {
 					apiRetStatus = StartGPIF();  /* reload waveform + SMStart */
@@ -460,7 +458,7 @@ CyFxSlFifoApplnUSBSetupCB (
 					CyU3PDmaMultiChannelReset (&glMultiChHandleSlFifoPtoU);
 					CyU3PUsbFlushEp(CY_FX_EP_CONSUMER);
 					glDMACount = 0;  /* prevent watchdog false-positive on stale count */
-					glWdgRecoveryCount = 0;  /* reset recovery cap */
+					health_reset_recovery_count();  /* reset recovery cap */
 					/* No longer streaming — park the ADC in low-power
 					 * standby via SHDN (issue #131). */
 					rx888r2_AdcStandby(CyTrue);

--- a/SDDC_FX3/health.c
+++ b/SDDC_FX3/health.c
@@ -20,6 +20,17 @@
 #include "health.h"
 #include "cyu3os.h"
 #include "cyu3system.h"
+#include "Application.h"   /* DebugPrint, FIFO_DMA_RX_SIZE, CY_FX_EP_CONSUMER, SDK GPIF/DMA/USB APIs */
+#include "protocol.h"      /* WDG_MAX_RECOVERY_DEFAULT */
+#include "Si5351.h"        /* si5351_clk0_enabled / si5351_pll_locked (recovery gate) */
+#include "gpif_states.h"   /* GPIF_TH0_BUSY etc. */
+
+/* Streaming-pipeline globals owned elsewhere, inspected and driven by the
+ * Level-1 streaming watchdog migrated into health_recover() (issue #115). */
+extern uint32_t glDMACount;                            /* StartStopApplication.c */
+extern uint32_t glCounter[20];                         /* DebugConsole.c */
+extern CyU3PDmaMultiChannel glMultiChHandleSlFifoPtoU; /* StartStopApplication.c */
+extern CyBool_t glIsApplnActive;                       /* RunApplication.c */
 
 /* If an EP0 vendor callback runs longer than this, declare it wedged
  * and reset the device.  Legitimate handlers complete in <100 ms
@@ -79,6 +90,19 @@ static volatile uint32_t glMainHeartbeat = 0;
 /* HANGMAIN test flag — set by the vendor handler in USBHandler.c,
  * read at the top of each main-loop iteration in RunApplication.c. */
 volatile uint8_t glHealthHangMain = 0;
+
+/* Level-1 streaming-watchdog recovery cap (migrated from RunApplication.c,
+ * issue #115).  glWdgMaxRecovery: 0 = unlimited, else stop attempting after
+ * N consecutive recoveries until health_reset_recovery_count() (STARTFX3 /
+ * STOPFX3) begins a fresh session. */
+static uint8_t glWdgMaxRecovery = WDG_MAX_RECOVERY_DEFAULT;
+static uint8_t glWdgRecoveryCount = 0;
+
+/* Streaming-stall sampler state — was static locals in the inline watchdog.
+ * glStallCount counts consecutive ~100 ms ticks with frozen DMA in a
+ * BUSY/WAIT state; glPrevDMACount is the previous glDMACount sample. */
+static uint32_t glPrevDMACount = 0;
+static uint8_t  glStallCount = 0;
 
 /* ThreadX timer used to pet the HWDT.  Per KB223337 the pet must
  * happen from a timer callback context, not from the main thread. */
@@ -157,9 +181,74 @@ void health_record_event(health_event_t event)
     }
 }
 
+void health_set_max_recovery(uint8_t max)
+{
+    glWdgMaxRecovery = max;
+}
+
+void health_reset_recovery_count(void)
+{
+    glWdgRecoveryCount = 0;
+}
+
+/* Level-1 streaming-stall detector.  Runs once per health_evaluate() tick
+ * (~10 Hz).  Samples glDMACount and the GPIF SM state, maintaining a
+ * 3-strike counter; returns CyTrue when the pipeline has been stuck in a
+ * BUSY/WAIT state with no DMA progress for 3 consecutive samples (~300 ms).
+ * The remedy lives in health_recover(HEALTH_WEDGED_STREAMING).  Migrated
+ * verbatim from the inline watchdog in RunApplication.c (issue #115); the
+ * `curDMA > 0` guard means a cold-start wedge (first buffer never arrives)
+ * is not yet detected — see #119 / #137. */
+static CyBool_t streaming_wedge_detected(void)
+{
+    uint32_t curDMA = glDMACount;
+
+    if (curDMA == glPrevDMACount && curDMA > 0)
+    {
+        uint8_t gpifState = 0xFF;
+        CyU3PGpifGetSMState(&gpifState);
+
+        if (gpifState == GPIF_TH0_BUSY || gpifState == GPIF_TH1_BUSY ||
+            gpifState == GPIF_TH1_WAIT || gpifState == GPIF_TH0_WAIT)
+        {
+            glStallCount++;
+            DebugPrint(4, "\r\nWDG: stall %d/3 SM=%d DMA=%u",
+                glStallCount, gpifState, curDMA);
+            if (glStallCount >= 3)  /* 300ms in BUSY/WAIT */
+            {
+                glStallCount = 0;
+                return CyTrue;
+            }
+        }
+        else
+        {
+            if (glStallCount > 0)
+                DebugPrint(4, "\r\nWDG: stall cleared SM=%d (was %d/3)",
+                    gpifState, glStallCount);
+            glStallCount = 0;
+        }
+    }
+    else
+    {
+        if (glStallCount > 0)
+            DebugPrint(4, "\r\nWDG: DMA resumed (%u->%u), stall cleared",
+                glPrevDMACount, curDMA);
+        glStallCount = 0;
+        glPrevDMACount = curDMA;
+    }
+    return CyFalse;
+}
+
 health_status_t health_evaluate(void)
 {
-    /* PR 2: one signal — EP0 handler duration vs timeout. */
+    /* Level 1 — advance the streaming-stall sampler every tick (only while
+     * streaming is active).  Sampled before the EP0 check so its state
+     * machine keeps advancing regardless of EP0 status. */
+    CyBool_t streaming_wedged =
+        glIsApplnActive ? streaming_wedge_detected() : CyFalse;
+
+    /* Level 4 — EP0 handler duration vs timeout.  Takes precedence: an EP0
+     * deadlock resets the whole device, so it wins over a streaming wedge. */
     if (glHealthState.ep0_handler_in_progress) {
         uint32_t now = CyU3PGetTime();
         uint32_t enter = glHealthState.ep0_handler_enter_ms;
@@ -169,6 +258,11 @@ health_status_t health_evaluate(void)
             return HEALTH_WEDGED_EP0;
         }
     }
+
+    if (streaming_wedged) {
+        return HEALTH_WEDGED_STREAMING;
+    }
+
     return HEALTH_OK;
 }
 
@@ -187,6 +281,66 @@ void health_recover(health_status_t status)
              * SDK call may itself be the thing hung, so avoid waiting. */
             CyU3PDeviceReset(CyFalse);
             /* Should not return. */
+            break;
+
+        case HEALTH_WEDGED_STREAMING:
+            /* Level 1 — streaming pipeline wedged in BUSY/WAIT with no DMA
+             * progress.  Soft-stop (force-stop fallback), reset the DMA
+             * channel + flush EP, and restart the GPIF SM if the ADC clock
+             * is healthy.  Migrated verbatim from RunApplication.c (#115). */
+            if (glWdgMaxRecovery > 0 && glWdgRecoveryCount >= glWdgMaxRecovery)
+            {
+                DebugPrint(4, "\r\nWDG: recovery limit (%d), waiting for STARTFX3",
+                    glWdgMaxRecovery);
+                return;
+            }
+            {
+                CyU3PReturnStatus_t rc_reset, rc_flush;
+                CyU3PReturnStatus_t rc_xfer = 0, rc_sm = 0;
+                CyBool_t hw_ok;
+                uint8_t smState = 0xFF;
+                uint32_t curDMA = glDMACount;
+
+                CyU3PGpifGetSMState(&smState);
+                glWdgRecoveryCount++;
+                DebugPrint(4, "\r\nWDG: === RECOVERY START === SM=%d DMA=%u recov=%d/%d",
+                    smState, curDMA, glWdgRecoveryCount, glWdgMaxRecovery);
+                /* Soft-stop: deassert FW_TRG so the SM exits to IDLE via the
+                 * !FW_TRG transitions.  Caveat: soft-stop needs the external
+                 * clock to advance the SM; if the Si5351 is dead or PLL
+                 * unlocked the SM can't transition and soft-stop fails — fall
+                 * back to force-stop. */
+                CyU3PGpifControlSWInput(CyFalse);
+                CyU3PThreadSleep(1);
+                smState = 0xFF;
+                CyU3PGpifGetSMState(&smState);
+                if (smState == GPIF_IDLE) {
+                    CyU3PGpifDisable(CyFalse);
+                } else {
+                    DebugPrint(4, "\r\nWDG: soft-stop fail SM=%d, forcing", smState);
+                    CyU3PGpifDisable(CyTrue);
+                }
+
+                rc_reset = CyU3PDmaMultiChannelReset(&glMultiChHandleSlFifoPtoU);
+                rc_flush = CyU3PUsbFlushEp(CY_FX_EP_CONSUMER);
+
+                /* Only restart streaming if the ADC clock is healthy — a
+                 * soft-stop with a dead clock leaves the SM unable to move. */
+                hw_ok = si5351_clk0_enabled() && si5351_pll_locked();
+                if (hw_ok)
+                {
+                    rc_xfer = CyU3PDmaMultiChannelSetXfer(
+                        &glMultiChHandleSlFifoPtoU, FIFO_DMA_RX_SIZE, 0);
+                    rc_sm = CyU3PGpifSMStart(0, 0);
+                    CyU3PGpifControlSWInput(CyTrue);
+                }
+                glCounter[2]++;  /* streaming fault counter — GETSTATS [15..18];
+                                  * also incremented by EP_UNDERRUN in USBHandler.c */
+                DebugPrint(4, "\r\nWDG: === RECOVERY %s === rst=%d flush=%d xfer=%d sm=%d",
+                    hw_ok ? "DONE" : "WAIT", rc_reset, rc_flush, rc_xfer, rc_sm);
+                glPrevDMACount = 0;
+                glDMACount = 0;
+            }
             break;
 
         case HEALTH_OK:

--- a/SDDC_FX3/health.h
+++ b/SDDC_FX3/health.h
@@ -43,6 +43,7 @@ typedef enum {
 typedef enum {
     HEALTH_OK = 0,
     HEALTH_WEDGED_EP0,        /* Vendor callback hung in SDK call (issue #104, #105) */
+    HEALTH_WEDGED_STREAMING,  /* DMA stalled in a GPIF BUSY/WAIT state — Level 1 (#115) */
     HEALTH_WEDGED_UNKNOWN,    /* Unidentified wedge — fall-through case */
 } health_status_t;
 
@@ -96,5 +97,18 @@ health_status_t health_evaluate(void);
  * by main loop when health_evaluate() returns anything other than
  * HEALTH_OK.  May call CyU3PDeviceReset() for catastrophic statuses. */
 void health_recover(health_status_t status);
+
+/* Recovery-cap control for the Level-1 streaming watchdog (migrated from
+ * RunApplication.c into health_recover, issue #115).
+ *
+ *   health_set_max_recovery()     — backs the WDG_MAX_RECOV SETARGFX3 arg.
+ *                                    0 = unlimited; else stop attempting
+ *                                    after N consecutive recoveries until
+ *                                    the host starts a new session.
+ *   health_reset_recovery_count() — called on STARTFX3 / STOPFX3 to begin
+ *                                    a fresh streaming session.
+ */
+void health_set_max_recovery(uint8_t max);
+void health_reset_recovery_count(void);
 
 #endif /* _INCLUDED_HEALTH_H_ */


### PR DESCRIPTION
Closes #115. Moves the Level-1 streaming watchdog out of `RunApplication.c`'s main loop into `health.c`, behind the `health_evaluate()`/`health_recover()` contract — a **pure behaviour-preserving refactor**.

> **Stacked on #136** (needs `gpif_states.h` from that PR). Base is `claude/cleanup_bugfix_0-1-1`; retarget to `main` once #136 merges.

## Why
`health.h`/`health.c` declare that *all* recovery goes through `health_evaluate`/`health_recover` — "no parallel mechanisms, no inline cleanup in handlers." The DMA-stall watchdog violated that by living inline in the main loop with its own static state and cap. This brings it into the cascade.

## What moved
- **`health_evaluate()`** gains `streaming_wedge_detected()` — advances a 3-strike DMA-stall sampler every tick while `glIsApplnActive`, returns `HEALTH_WEDGED_STREAMING`. EP0 (Level 4) keeps precedence; the sampler advances every tick regardless.
- **`health_recover(HEALTH_WEDGED_STREAMING)`** — cap check + the soft-stop/force-stop → `DmaMultiChannelReset` → `FlushEp` → Si5351 health-gate → `SetXfer` → `SMStart` sequence, `glCounter[2]++`, and `prevDMACount`/`glDMACount` reset on recovery. Migrated verbatim.
- **Recovery cap** (`glWdgMaxRecovery`/`glWdgRecoveryCount`) + sampler state → `health.c` statics, behind `health_set_max_recovery()` / `health_reset_recovery_count()`.
- **`RunApplication.c`** −107 lines: the inline block and `glWdg*` defs gone; the watchdog now runs via the existing `health_tick()` (self-gates on `glIsApplnActive`, so a no-op pre-enum). Drops the now-unused `glCounter`/`glMultiChHandleSlFifoPtoU` externs.
- **`USBHandler.c`**: `WDG_MAX_RECOV` SETARGFX3 → `health_set_max_recovery()`; STARTFX3/STOPFX3 cap reset → `health_reset_recovery_count()`.

## Acceptance (issue #115)
- [x] No `CyU3PGpifGetSMState`/`CyU3PDmaMultiChannelReset`/`CyU3PGpifDisable`/`glWdg*` arithmetic left in `RunApplication.c` (grep-clean).
- [x] No direct `glWdg*` writes in `USBHandler.c`.
- [x] `RunApplication.c` drops ~107 lines.
- [x] GETSTATS `[15..18]` (`glCounter[2]`) and the `WDG_MAX_RECOV` round-trip unchanged.
- [x] Clean `arm-none-eabi-gcc 13.2` build, no warnings.

## Behaviour note
Same detection thresholds, recovery sequence, and cap semantics. The one intended new debug line is the generic `HEALTH: status=2, recovering` from `health_tick()` before the existing `WDG:` lines (UART-only). Not byte-identical (code crosses translation units), so it was validated by a bench soak rather than a binary diff.

## Test plan
- [x] CI `build.yml` green (firmware + host tools).
- [x] **Bench-validated** — 3 h soak, seed 3, 5713 cycles, same scenario sequence as the pre-refactor #136 baseline. Watchdog behaviour matches exactly: `wedge_recovery` **350/350**, `watchdog_cap_observe` **115/115**, `watchdog_cap_restart` **119/119**, `streaming_faults: 13` (every recovery tracked via `glCounter[2]`/GETSTATS), Level-4 `test_health_recovery` 62/62, Level-5 `test_main_recovery` 72/72, `gpif_soft_stop` 78/78, `stop_gpif_state` 66/66. Total 1 failure / 5713 (0.02%) — a single `i2c_write_bad_addr` transient EP0 STALL unrelated to this refactor (see #135). `health_checks 5713/5713`.

## Unblocks
- #137 — the `HEALTH_WEDGED_STREAMING` plumbing this adds is where the cold-start detection-broadening + reset escalation (from the soak triage on #119) will land.

https://claude.ai/code/session_01Rp36gV7pHqjFxirKnre4Cu