### PR TITLE
tests: post-fuzz streaming/clock-health gate (#148) + deterministic ep0_sweep (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ queryable via the `TESTFX3` vendor command.
 
 ### Added
 
+- **Post-fuzz streaming/clock-health gate + deterministic EP0 direction sweep.**
+  The fuzz health gate (`TESTFX3`+`GETSTATS`) couldn't see a device left unable
+  to stream after a run reconfigured the Si5351 via `I2CWFX3`, so a dead-clock
+  device reported PASS. `protocol_fuzz`/`stream_fuzz`/`dir_mismatch` now probe
+  streaming at the end: streams ⇒ PASS; EP0-healthy-but-not-streaming ⇒
+  reload-verify (with `-F`: reload + re-check — recovers ⇒ PASS-with-note,
+  can't ⇒ FAIL; without `-F`: WARN); EP0 wedged ⇒ FAIL (#148). New `ep0_sweep`
+  deterministically exercises every `bRequest` 0–255 × {IN,OUT} (skipping
+  `RESETFX3`/`HANG*`) and asserts no wrong-direction/unknown request is
+  accepted and the device survives — the provable regression for the #142
+  direction guard, complementing the seed-sampled fuzzers (#149). Host-side
+  test tooling only.
 - **Host enumeration-race test coverage + open backoff.** `open_rx888()`
   now absorbs a udev/libusb permission-settle race: it distinguishes a
   present-but-unopenable device (retries with bounded backoff, ~2 s, env

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,7 +32,7 @@ FX3_OBJS := fx3_cmd.o fx3_usb.o fx3_stats.o fx3_bulk.o fx3_fuzz.o fx3_lifecycle.
 FX3_HDRS := fx3_proto.h fx3_usb.h fx3_stats.h fx3_bulk.h fx3_fuzz.h fx3_lifecycle.h
 
 fx3_cmd: $(FX3_OBJS)
-	$(CC) $(FX3_CFLAGS) -o $@ $(FX3_OBJS) $(LIBUSB_LDLIBS)
+	$(CC) $(FX3_CFLAGS) -o $@ $(FX3_OBJS) $(LIBUSB_LDLIBS) $(LDLIBS)
 
 %.o: %.c $(FX3_HDRS)
 	$(CC) $(FX3_CFLAGS) -c -o $@ $<

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,8 +14,12 @@
 
 CC      ?= gcc
 CFLAGS  ?= -O2 -Wall -Wextra -Wno-unused-parameter
-LDLIBS  := $(shell pkg-config --libs libusb-1.0)
-CFLAGS  += $(shell pkg-config --cflags libusb-1.0)
+
+# Keep libusb discovery lazy and scoped to fx3_cmd/rx888_stream builds so
+# host-only targets such as check-health remain usable without libusb-dev.
+LIBUSB_CFLAGS = $(shell pkg-config --cflags libusb-1.0)
+LIBUSB_LDLIBS = $(shell pkg-config --libs libusb-1.0)
+FX3_CFLAGS    = $(CFLAGS) $(LIBUSB_CFLAGS)
 
 # rx888_tools submodule paths
 RX888_TOOLS := rx888_tools
@@ -28,10 +32,10 @@ FX3_OBJS := fx3_cmd.o fx3_usb.o fx3_stats.o fx3_bulk.o fx3_fuzz.o fx3_lifecycle.
 FX3_HDRS := fx3_proto.h fx3_usb.h fx3_stats.h fx3_bulk.h fx3_fuzz.h fx3_lifecycle.h
 
 fx3_cmd: $(FX3_OBJS)
-	$(CC) $(CFLAGS) -o $@ $(FX3_OBJS) $(LDLIBS)
+	$(CC) $(FX3_CFLAGS) -o $@ $(FX3_OBJS) $(LIBUSB_LDLIBS)
 
 %.o: %.c $(FX3_HDRS)
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(FX3_CFLAGS) -c -o $@ $<
 
 rx888_stream: $(RX888_STREAM_BIN)
 	@# Symlink into tests/ so fw_test.sh finds it alongside fx3_cmd

--- a/tests/README.md
+++ b/tests/README.md
@@ -263,8 +263,28 @@ is visible — enough to reproduce with the same seed.
 ```
 ./fx3_cmd protocol_fuzz [ops] [seed]     # default 5000 ops
 ./fx3_cmd stream_fuzz   [secs] [seed]    # default 60 s
+./fx3_cmd dir_mismatch  [ops] [seed]     # well-formed, wrong direction only (#142)
+./fx3_cmd ep0_sweep                      # deterministic 0..255 x IN/OUT (#149)
 ./fx3_cmd protocol_fuzz 5000 0x12345678  # reproducible run
 ```
+
+**Streaming/clock-health gate (#148).** The periodic gate only checks
+`TESTFX3` + `GETSTATS`, which a run can pass while having reconfigured the
+Si5351 via `I2CWFX3` and left the device unable to stream.  So at the end of
+a `protocol_fuzz`/`stream_fuzz`/`dir_mismatch` run the harness also **probes
+streaming**: if the device still streams it's a clean PASS; if EP0 is healthy
+but streaming is down (almost always the fuzz reconfigured the clock — a
+legal host op, not a firmware bug), it **reload-verifies** — with `-F` it
+reloads firmware and re-checks streaming (recovers ⇒ PASS-with-note, can't ⇒
+FAIL); without `-F` it WARNs.  A true EP0 wedge still FAILs immediately.
+
+**`ep0_sweep` (#149)** deterministically sends every `bRequest` 0–255 in both
+directions (skipping `RESETFX3`/`HANG*`) and asserts the #142 invariant across
+the whole space: no wrong-direction or unknown request is accepted, and the
+device survives the sweep (no wedge/reset).  It's the provable regression for
+the direction guard, complementing the seed-sampled `protocol_fuzz`.  It
+mutates clock/GPIO state (it runs real OUT commands), so reload before
+streaming afterward.
 
 **`protocol_fuzz`** generates random EP0 control transfers: `bRequest`
 (biased to the known command set, plus unknown codes), `bmRequestType`

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -5283,6 +5283,49 @@ static int do_test_main_recovery(libusb_device_handle *h)
 /* Usage and main                                                     */
 /* ------------------------------------------------------------------ */
 
+/* #148: a fuzz run returned 2 — the device is EP0-healthy but no longer
+ * streaming, almost always because the fuzzer reconfigured the Si5351 via
+ * I2CWFX3 (a legal host op, not a firmware bug).  Confirm it's *recoverable*:
+ * reload firmware and re-verify streaming.  Needs a firmware image (-F or the
+ * ../SDDC_FX3 fallback); without one we can only WARN.  Returns 0 if the
+ * device streams again (or we couldn't verify), 1 if it cannot stream even
+ * after a reload (real firmware/clock damage). */
+static int fuzz_reload_verify(libusb_device_handle **h)
+{
+    const char *fw = g_firmware_path;
+    const char *fallback = "../SDDC_FX3/SDDC_FX3.img";
+    if (!fw || access(fw, R_OK) != 0)
+        fw = (access(fallback, R_OK) == 0) ? fallback : NULL;
+
+    if (!fw) {
+        printf("# reload-verify: no firmware image (-F) — cannot confirm "
+               "recovery.  Reload before streaming.  Treating EP0 survival as PASS.\n");
+        return 0;
+    }
+    printf("# reload-verify: reloading firmware to confirm the device recovers...\n");
+    if (*h) { close_rx888(*h); *h = NULL; }
+    if (do_reload(g_ctx, fw) != 0) {
+        printf("FAIL: reload failed during recovery verify\n");
+        return 1;
+    }
+    *h = open_rx888(g_ctx);
+    if (!*h) {
+        printf("FAIL: reopen after reload failed\n");
+        return 1;
+    }
+    cmd_u32(*h, STARTADC, 32000000);
+    int got = primed_start_and_read_retry(*h, 16384, 2000);
+    cmd_u32(*h, STOPFX3, 0);
+    if (got > 0) {
+        printf("PASS: device recovered after reload — the fuzz run had "
+               "reconfigured the Si5351; firmware is fine.\n");
+        return 0;
+    }
+    printf("FAIL: device cannot stream even after reload — possible "
+           "firmware/clock damage.\n");
+    return 1;
+}
+
 static void usage(const char *prog)
 {
     fprintf(stderr,
@@ -5359,6 +5402,7 @@ static void usage(const char *prog)
         "                               default 5000 ops; prints coverage + reproduce seed)\n"
         "  stream_fuzz [secs] [seed]    Seeded bulk/host-lifecycle fuzzer (#139; default 60s)\n"
         "  dir_mismatch [ops] [seed]    Well-formed EP0 requests, wrong direction only (#142 isolation)\n"
+        "  ep0_sweep                    Deterministic bRequest 0..255 x IN/OUT direction sweep (#149)\n"
         "  reopen_race_storm            Tight close/reopen storm; device must stay healthy (#143)\n"
         "  two_actor_open               2nd process hammers EP0 while streaming (#143)\n"
         "  soak [hours] [seed] [max] [-q] [--weight NAME=N]...\n"
@@ -5728,16 +5772,22 @@ int main(int argc, char **argv)
         long n = (argc >= 3) ? (long)parse_num(argv[2]) : 5000;
         uint64_t seed = (argc >= 4) ? (uint64_t)strtoull(argv[3], NULL, 0) : 0;
         rc = fuzz_protocol(&h, n, seed);
+        if (rc == 2) rc = fuzz_reload_verify(&h);   /* #148 */
 
     } else if (strcmp(cmd, "stream_fuzz") == 0) {
         double secs = (argc >= 3) ? atof(argv[2]) : 60.0;
         uint64_t seed = (argc >= 4) ? (uint64_t)strtoull(argv[3], NULL, 0) : 0;
         rc = fuzz_stream(&h, secs, seed);
+        if (rc == 2) rc = fuzz_reload_verify(&h);   /* #148 */
 
     } else if (strcmp(cmd, "dir_mismatch") == 0) {
         long n = (argc >= 3) ? (long)parse_num(argv[2]) : 2000;
         uint64_t seed = (argc >= 4) ? (uint64_t)strtoull(argv[3], NULL, 0) : 0;
         rc = fuzz_dir_mismatch(&h, n, seed);
+        if (rc == 2) rc = fuzz_reload_verify(&h);   /* #148 */
+
+    } else if (strcmp(cmd, "ep0_sweep") == 0) {
+        rc = fuzz_ep0_sweep(&h);                    /* #149 */
 
     } else if (strcmp(cmd, "soak") == 0) {
         /* Pass &h so soak_try_reacquire() (which closes and replaces

--- a/tests/fx3_fuzz.c
+++ b/tests/fx3_fuzz.c
@@ -629,9 +629,19 @@ int fuzz_ep0_sweep(libusb_device_handle **h_inout)
                "(first: bReq=0x%02X %s) — direction-guard gap (#142)\n",
                unexpected, first_bad >> 1, (first_bad & 1) ? "IN" : "OUT");
         rc = 1;
+    } else if (rc == 0 && log.resets > 0) {
+        /* fuzz_gate counts (and re-acquires through) re-enumerations — a
+         * boot_count change in fuzz_probe or a NO_DEVICE reacquire — without
+         * failing.  The sweep's invariant is that NO (bRequest,direction)
+         * resets the device, so enforce it explicitly here; otherwise a
+         * reset-inducing request could still print "boot steady". */
+        printf("FAIL ep0_sweep: device reset %u time(s) during the sweep — a "
+               "(bRequest,direction) request triggered a re-enumeration\n",
+               log.resets);
+        rc = 1;
     } else if (rc == 0) {
         printf("PASS ep0_sweep: %llu requests (all bRequest x IN/OUT), no "
-               "wrong-direction/unknown accepted, device healthy (boot steady). "
+               "wrong-direction/unknown accepted, no resets, device healthy. "
                "NOTE: clock/GPIO mutated — reload before streaming.\n",
                (unsigned long long)log.seq);
     }

--- a/tests/fx3_fuzz.c
+++ b/tests/fx3_fuzz.c
@@ -332,6 +332,19 @@ static void protocol_fuzz_step(libusb_device_handle *h, struct fuzz_rng *rng,
     fuzz_record(log, &op, streaming);
 }
 
+/* #148: does the device still stream?  The EP0 health gate only checks
+ * TESTFX3 + GETSTATS, so a run that left the device unable to stream (e.g.
+ * protocol_fuzz reconfigured the Si5351 via I2CWFX3) could still report PASS.
+ * Probe streaming so the final verdict is honest.  Returns 1 if data flows. */
+static int fuzz_streams_ok(libusb_device_handle *h)
+{
+    if (!h) return 0;
+    cmd_u32(h, STARTADC, 32000000);
+    int got = primed_start_and_read_retry(h, 16384, 2000);
+    cmd_u32(h, STOPFX3, 0);
+    return got > 0;
+}
+
 static int protocol_fuzz_core(libusb_device_handle **h_inout, long num_ops,
                               uint64_t seed, int quiet)
 {
@@ -380,10 +393,21 @@ static int protocol_fuzz_core(libusb_device_handle **h_inout, long num_ops,
     if (!quiet) {
         signal(SIGINT, SIG_DFL);
         fuzz_coverage_report(&log);
-        if (rc == 0)
-            printf("PASS protocol_fuzz: %llu ops, %u resets, %u/%u health checks ok\n",
-                   (unsigned long long)log.seq, log.resets,
-                   log.health_checks - log.health_fails, log.health_checks);
+        if (rc == 0) {
+            /* #148: EP0 survived — confirm the device still streams. */
+            if (fuzz_streams_ok(h)) {
+                printf("PASS protocol_fuzz: %llu ops, %u resets, %u/%u health "
+                       "checks ok (device streams)\n",
+                       (unsigned long long)log.seq, log.resets,
+                       log.health_checks - log.health_fails, log.health_checks);
+            } else {
+                printf("WARN protocol_fuzz: %llu ops, EP0 healthy but NOT "
+                       "streaming — Si5351 likely reconfigured by I2CWFX3 fuzz; "
+                       "device needs a reload before streaming.\n",
+                       (unsigned long long)log.seq);
+                rc = 2;   /* caller reload-verifies if -F is available */
+            }
+        }
     } else if (rc != 0) {
         /* Burst mode still surfaces the seed so a soak failure reproduces. */
         printf(">>> protocol_fuzz_burst FAIL seed=0x%016llx\n",
@@ -485,10 +509,132 @@ int fuzz_dir_mismatch(libusb_device_handle **h_inout, long num_ops, uint64_t see
     if (h) cmd_u32(h, STOPFX3, 0);
     signal(SIGINT, SIG_DFL);
     fuzz_coverage_report(&log);
-    if (rc == 0)
-        printf("PASS dir_mismatch: %llu wrong-direction ops, device healthy "
-               "(direction mismatch did NOT wedge EP0)\n",
+    if (rc == 0) {
+        /* #148: dir_mismatch STALLs all wrong-direction I2CWFX3 (no Si5351
+         * write lands), so a healthy device should still stream — a strong
+         * signal here. */
+        if (fuzz_streams_ok(h)) {
+            printf("PASS dir_mismatch: %llu wrong-direction ops, device healthy "
+                   "and streaming (direction mismatch did NOT wedge EP0)\n",
+                   (unsigned long long)log.seq);
+        } else {
+            printf("WARN dir_mismatch: %llu ops, EP0 healthy but NOT streaming — "
+                   "unexpected (dir_mismatch shouldn't reconfigure the Si5351); "
+                   "needs reload-verify.\n", (unsigned long long)log.seq);
+            rc = 2;
+        }
+    }
+    *h_inout = h;
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/* ep0_sweep — deterministic exhaustive bRequest x direction (#149)   */
+/* ------------------------------------------------------------------ */
+
+/* Correct data-phase direction for a known command: 1=IN, 0=OUT, -1=unknown.
+ * Reuses the DIR_TMPL classification. */
+static int known_dir(uint8_t code)
+{
+    for (int i = 0; i < NDIR_TMPL; i++)
+        if (DIR_TMPL[i].code == code) return DIR_TMPL[i].dir_in;
+    return -1;
+}
+
+/* Deterministically send every bRequest 0..255 in BOTH directions (IN/OUT)
+ * and assert the #142 invariant across the whole space: no wrong-direction or
+ * unknown request is accepted, and the device survives the entire sweep
+ * (no wedge, no reset).  Unlike the seed-sampled protocol_fuzz/dir_mismatch,
+ * this is a provable, repeatable pass over the full small space.
+ *
+ * Destructive: sending real OUT commands runs their side effects (STARTADC,
+ * GPIOFX3, ...), so it mutates clock/GPIO state — reload before streaming
+ * afterward.  Skips RESETFX3/HANG* (they reset/hang the device).  wLength=64
+ * (<= EP0 max, no oversize STALL) so IN handlers have room and OUT handlers
+ * get a full data phase. */
+int fuzz_ep0_sweep(libusb_device_handle **h_inout)
+{
+    libusb_device_handle *h = *h_inout;
+    struct fuzz_log log; fuzz_log_init(&log);
+    uint32_t boot = 0;
+
+    fuzz_stop = 0;
+    signal(SIGINT, fuzz_sigint);
+    printf("=== EP0_SWEEP === bRequest 0..255 x {OUT,IN}, wLength=64 "
+           "(deterministic; destructive — mutates clock/GPIO)\n");
+
+    if (fuzz_gate(&h, &log, &boot, /*quiet=*/0) != 0) {
+        printf("FAIL ep0_sweep: device unhealthy before start\n");
+        signal(SIGINT, SIG_DFL);
+        *h_inout = h;
+        return 1;
+    }
+
+    static uint8_t buf[64];
+    memset(buf, 0, sizeof(buf));
+    int unexpected = 0;
+    int first_bad = -1;
+    int rc = 0;
+
+    for (int code = 0; code < 256 && !fuzz_stop; code++) {
+        if (code == RESETFX3 || code == HANGFX3 ||
+            code == HANGMAIN || code == HANGCOLDSTART)
+            continue;   /* destructive — would reset/hang the device */
+
+        for (int in = 0; in < 2; in++) {
+            uint8_t bmrt = (in ? LIBUSB_ENDPOINT_IN : LIBUSB_ENDPOINT_OUT)
+                         | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE;
+            int r = libusb_control_transfer(h, bmrt, (uint8_t)code, 0, 0,
+                                            buf, (uint16_t)sizeof(buf), 250);
+            struct fuzz_op op = { bmrt, (uint8_t)code, 0, 0,
+                                  (uint16_t)sizeof(buf), (uint16_t)sizeof(buf), r };
+            fuzz_record(&log, &op, 0);
+
+            /* #142 invariant: a wrong-direction or unknown request must NOT be
+             * accepted.  expected_accept = known command in its correct
+             * direction (it may still legitimately STALL on these zero args). */
+            int kd = known_dir((uint8_t)code);
+            int expected_accept = (kd >= 0 && in == kd);
+            if (r >= 0 && !expected_accept) {
+                unexpected++;
+                if (first_bad < 0) first_bad = (code << 1) | in;
+            }
+        }
+
+        if ((code & 0x1f) == 0x1f) {   /* health-gate (and STOP) every 32 codes */
+            cmd_u32(h, STOPFX3, 0);
+            if (fuzz_gate(&h, &log, &boot, /*quiet=*/0) != 0) {
+                printf("FAIL ep0_sweep: device wedged after bRequest 0x%02X\n", code);
+                fuzz_dump(&log, 0, "ep0_sweep", h);
+                rc = 1;
+                break;
+            }
+        }
+    }
+
+    if (rc == 0) {
+        cmd_u32(h, STOPFX3, 0);
+        if (fuzz_gate(&h, &log, &boot, /*quiet=*/0) != 0) {
+            printf("FAIL ep0_sweep: device wedged after the sweep\n");
+            fuzz_dump(&log, 0, "ep0_sweep", h);
+            rc = 1;
+        }
+    }
+
+    signal(SIGINT, SIG_DFL);
+    fuzz_coverage_report(&log);
+
+    if (rc == 0 && unexpected > 0) {
+        printf("FAIL ep0_sweep: %d wrong-direction/unknown request(s) ACCEPTED "
+               "(first: bReq=0x%02X %s) — direction-guard gap (#142)\n",
+               unexpected, first_bad >> 1, (first_bad & 1) ? "IN" : "OUT");
+        rc = 1;
+    } else if (rc == 0) {
+        printf("PASS ep0_sweep: %llu requests (all bRequest x IN/OUT), no "
+               "wrong-direction/unknown accepted, device healthy (boot steady). "
+               "NOTE: clock/GPIO mutated — reload before streaming.\n",
                (unsigned long long)log.seq);
+    }
     *h_inout = h;
     return rc;
 }
@@ -704,9 +850,17 @@ static int stream_fuzz_core(libusb_device_handle **h_inout, double seconds,
         printf("  stream_fuzz: %llu bulk/EP0 ops, %u resets, %u/%u health ok\n",
                (unsigned long long)log.seq, log.resets,
                log.health_checks - log.health_fails, log.health_checks);
-        if (rc == 0)
-            printf("PASS stream_fuzz: device survived %.1fs of stream fuzzing\n",
-                   seconds);
+        if (rc == 0) {
+            /* #148: confirm the device still streams after the run. */
+            if (fuzz_streams_ok(h)) {
+                printf("PASS stream_fuzz: device survived %.1fs of stream fuzzing "
+                       "(still streams)\n", seconds);
+            } else {
+                printf("WARN stream_fuzz: survived %.1fs but EP0-healthy and NOT "
+                       "streaming — needs reload-verify.\n", seconds);
+                rc = 2;
+            }
+        }
     } else if (rc != 0) {
         printf(">>> stream_fuzz_burst FAIL seed=0x%016llx\n",
                (unsigned long long)seed);

--- a/tests/fx3_fuzz.h
+++ b/tests/fx3_fuzz.h
@@ -28,6 +28,15 @@ int fuzz_stream(libusb_device_handle **h_inout, double seconds, uint64_t seed);
  * flipped — confirms wrong-direction alone wedges EP0 (build-free falsifier). */
 int fuzz_dir_mismatch(libusb_device_handle **h_inout, long num_ops, uint64_t seed);
 
+/* #149: deterministic exhaustive sweep of every bRequest 0..255 x {IN,OUT};
+ * asserts no wrong-direction/unknown request is accepted and the device
+ * survives — the regression test for the #142 direction guard. */
+int fuzz_ep0_sweep(libusb_device_handle **h_inout);
+
+/* #148: the standalone fuzzers return 2 when the device is EP0-healthy but no
+ * longer streaming (Si5351 likely reconfigured by fuzz); main() maps that to a
+ * reload-and-re-verify recovery check. */
+
 /* Bounded soak bursts — seed derived from the soak's rand() so they stay
  * reproducible from the soak seed.  Obey soak conventions (STOPFX3 on exit,
  * no intentional re-enumeration). */


### PR DESCRIPTION
Closes #148, closes #149. Built on the merged #142 (direction guard) so `ep0_sweep` validates against a coherent source.

## #148 — post-fuzz streaming/clock-health gate
The fuzz health gate (`TESTFX3`+`GETSTATS`) couldn't see a device left unable to stream after a run reconfigured the Si5351 via `I2CWFX3` — so a dead-clock device reported PASS (observed this session: `protocol_fuzz` PASS, then a 50% soak failure with `si5351=0x00`, `i2c_failures` climbing).

`protocol_fuzz`/`stream_fuzz`/`dir_mismatch` now probe streaming at the end (`fuzz_streams_ok()`):
- **streams** → PASS;
- **EP0 healthy but not streaming** → core returns `rc=2`; `main()` runs `fuzz_reload_verify()`: with `-F` (or the `../SDDC_FX3` fallback) it reloads firmware and re-checks — recovers ⇒ PASS-with-note, can't ⇒ FAIL; without an image ⇒ WARN;
- **EP0 wedged** → FAIL upstream (unchanged).

Treating a fuzz-reconfigured clock as WARN-and-verify (not a hard FAIL) avoids false-failing the fuzzer for a *legal* host op (writing the Si5351). Soak bursts (`quiet`) skip the probe → unchanged.

## #149 — `ep0_sweep`
Deterministic: every `bRequest` 0–255 × {IN, OUT} (skipping `RESETFX3`/`HANG*`), `wLength=64`, health-gated every 32 codes. Asserts the #142 invariant across the whole space — **no wrong-direction or unknown request is accepted** (`known_dir()` reuses `DIR_TMPL`) and the device survives (no wedge/reset). The provable regression for the direction guard, complementing the seed-sampled `protocol_fuzz`/`dir_mismatch`. Destructive (runs real OUT commands → mutates clock/GPIO) — reload after.

## Status
Draft pending CI + hardware validation on flashed 2.6:
- `./fx3_cmd ep0_sweep` → PASS (no wrong-dir/unknown accepted; leaves clock off — reload after)
- `./fx3_cmd -F "$FW" protocol_fuzz 5000 1` → WARN → reload-verify → "recovered after reload" (PASS)
- `./fx3_cmd -F "$FW" dir_mismatch 2000 1` → streams (PASS, no reload needed)

Host test tooling only; no firmware change. Clean `-Wall -Wextra` build; `check-health` passes.

https://claude.ai/code/session_01XLg8ToK3L8DhoV4QWtFMae

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLg8ToK3L8DhoV4QWtFMae)_