### PR TITLE
tests: scope libusb pkg-config to fx3 tool builds

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,7 +32,7 @@ FX3_OBJS := fx3_cmd.o fx3_usb.o fx3_stats.o fx3_bulk.o fx3_fuzz.o fx3_lifecycle.
 FX3_HDRS := fx3_proto.h fx3_usb.h fx3_stats.h fx3_bulk.h fx3_fuzz.h fx3_lifecycle.h
 
 fx3_cmd: $(FX3_OBJS)
-	$(CC) $(FX3_CFLAGS) -o $@ $(FX3_OBJS) $(LIBUSB_LDLIBS)
+	$(CC) $(FX3_CFLAGS) -o $@ $(FX3_OBJS) $(LIBUSB_LDLIBS) $(LDLIBS)
 
 %.o: %.c $(FX3_HDRS)
 	$(CC) $(FX3_CFLAGS) -c -o $@ $<

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,8 +14,12 @@
 
 CC      ?= gcc
 CFLAGS  ?= -O2 -Wall -Wextra -Wno-unused-parameter
-LDLIBS  := $(shell pkg-config --libs libusb-1.0)
-CFLAGS  += $(shell pkg-config --cflags libusb-1.0)
+
+# Keep libusb discovery lazy and scoped to fx3_cmd/rx888_stream builds so
+# host-only targets such as check-health remain usable without libusb-dev.
+LIBUSB_CFLAGS = $(shell pkg-config --cflags libusb-1.0)
+LIBUSB_LDLIBS = $(shell pkg-config --libs libusb-1.0)
+FX3_CFLAGS    = $(CFLAGS) $(LIBUSB_CFLAGS)
 
 # rx888_tools submodule paths
 RX888_TOOLS := rx888_tools
@@ -28,10 +32,10 @@ FX3_OBJS := fx3_cmd.o fx3_usb.o fx3_stats.o fx3_bulk.o fx3_fuzz.o fx3_lifecycle.
 FX3_HDRS := fx3_proto.h fx3_usb.h fx3_stats.h fx3_bulk.h fx3_fuzz.h fx3_lifecycle.h
 
 fx3_cmd: $(FX3_OBJS)
-	$(CC) $(CFLAGS) -o $@ $(FX3_OBJS) $(LDLIBS)
+	$(CC) $(FX3_CFLAGS) -o $@ $(FX3_OBJS) $(LIBUSB_LDLIBS)
 
 %.o: %.c $(FX3_HDRS)
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(FX3_CFLAGS) -c -o $@ $<
 
 rx888_stream: $(RX888_STREAM_BIN)
 	@# Symlink into tests/ so fw_test.sh finds it alongside fx3_cmd


### PR DESCRIPTION
### Motivation

- Prevent `pkg-config` for `libusb-1.0` from affecting host-only targets so `check-health` and other host tests remain usable on machines without libusb development packages installed.

### Description

- Move `pkg-config` lookups into `LIBUSB_CFLAGS` and `LIBUSB_LDLIBS` and introduce `FX3_CFLAGS = $(CFLAGS) $(LIBUSB_CFLAGS)` so libusb flags are discovered lazily.
- Use `$(FX3_CFLAGS)` and `$(LIBUSB_LDLIBS)` in the `fx3_cmd` link and object compile rules instead of appending to global `CFLAGS`/`LDLIBS` at parse time.
- This change scopes libusb discovery to the `fx3_cmd`/`rx888_stream` build rules only and leaves host-only targets (e.g., `check-health`) independent of libusb headers.

### Testing

- Ran `make -C tests check-health` which built and executed the host `health_eval_test` and reported all checks passed.
- Attempted `make -C tests` to build `fx3_cmd`, which failed in this environment due to missing `libusb-1.0` development headers and blocked `apt` access; this is an environment limitation and not a regression in the Makefile.
- Verified `make -C tests clean` and `git diff --check` showed no whitespace or parse errors after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2049b55d3c832190ab2685f3737aa9)