### PR TITLE
firmware: malformed-I2C EP0 wedge — i2c_fuzz isolation (#154)

### DIFF
--- a/SDDC_FX3/i2cmodule.c
+++ b/SDDC_FX3/i2cmodule.c
@@ -29,7 +29,7 @@ I2cInit ()
      * The data transfer is done via DMA. */
     CyU3PMemSet ((uint8_t *)&i2cConfig, 0, sizeof(i2cConfig));
     i2cConfig.bitRate    = I2C_BITRATE;
-    i2cConfig.busTimeout = 0xFFFFFFFF;
+    i2cConfig.busTimeout = I2C_BUS_TIMEOUT;   /* finite; see i2cmodule.h (#154) */
     i2cConfig.dmaTimeout = 0xFFFF;
     i2cConfig.isDma      = CyFalse;
     status = CyU3PI2cSetConfig (&i2cConfig, NULL);

--- a/SDDC_FX3/i2cmodule.h
+++ b/SDDC_FX3/i2cmodule.h
@@ -7,6 +7,15 @@
 /* I2C Data rate */
 #define I2C_BITRATE        (400000)
 
+/* I2C bus timeout, in FX3 core clocks (403.2 MHz), i.e. how long SCL may be
+ * held low before CyU3PI2cReceiveBytes/TransmitBytes give up.  Formerly
+ * 0xFFFFFFFF (~10.6 s), which let a stranded/clock-stretched bus block the
+ * EP0 vendor handler long enough to trip the handler-liveness watchdog and
+ * wedge control transfers (issue #154).  ~10 ms is far longer than any
+ * legitimate 400 kHz transfer yet short enough to keep EP0 responsive.
+ *   4,032,000 core clocks / 403.2 MHz = 10.0 ms */
+#define I2C_BUS_TIMEOUT    (4032000u)
+
 CyU3PReturnStatus_t I2cInit();
 
 CyU3PReturnStatus_t I2cTransferW1 (  // Write one byte only

--- a/tests/README.md
+++ b/tests/README.md
@@ -265,6 +265,7 @@ is visible — enough to reproduce with the same seed.
 ./fx3_cmd stream_fuzz   [secs] [seed]    # default 60 s
 ./fx3_cmd dir_mismatch  [ops] [seed]     # well-formed, wrong direction only (#142)
 ./fx3_cmd ep0_sweep                      # deterministic 0..255 x IN/OUT (#149)
+./fx3_cmd i2c_fuzz      [ops] [seed]     # malformed I2CWFX3/I2CRFX3 only (#154 isolation)
 ./fx3_cmd protocol_fuzz 5000 0x12345678  # reproducible run
 ```
 

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -5404,6 +5404,7 @@ static void usage(const char *prog)
         "  dir_mismatch [ops] [seed]    Well-formed EP0 requests, wrong direction only (#142 isolation)\n"
         "  ep0_sweep                    Deterministic bRequest 0..255 x IN/OUT direction sweep (#149)\n"
         "  i2c_fuzz [ops] [seed]        Malformed I2CWFX3/I2CRFX3 only (#154 isolation)\n"
+        "  oversend_fuzz [ops] [seed]   Short-wLength on fixed-size IN responders (#154 isolation)\n"
         "  reopen_race_storm            Tight close/reopen storm; device must stay healthy (#143)\n"
         "  two_actor_open               2nd process hammers EP0 while streaming (#143)\n"
         "  soak [hours] [seed] [max] [-q] [--weight NAME=N]...\n"
@@ -5794,6 +5795,11 @@ int main(int argc, char **argv)
         long n = (argc >= 3) ? (long)parse_num(argv[2]) : 5000;
         uint64_t seed = (argc >= 4) ? (uint64_t)strtoull(argv[3], NULL, 0) : 0;
         rc = fuzz_i2c(&h, n, seed);                 /* #154 isolation */
+
+    } else if (strcmp(cmd, "oversend_fuzz") == 0) {
+        long n = (argc >= 3) ? (long)parse_num(argv[2]) : 5000;
+        uint64_t seed = (argc >= 4) ? (uint64_t)strtoull(argv[3], NULL, 0) : 0;
+        rc = fuzz_oversend(&h, n, seed);            /* #154 isolation */
 
     } else if (strcmp(cmd, "soak") == 0) {
         /* Pass &h so soak_try_reacquire() (which closes and replaces

--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -5403,6 +5403,7 @@ static void usage(const char *prog)
         "  stream_fuzz [secs] [seed]    Seeded bulk/host-lifecycle fuzzer (#139; default 60s)\n"
         "  dir_mismatch [ops] [seed]    Well-formed EP0 requests, wrong direction only (#142 isolation)\n"
         "  ep0_sweep                    Deterministic bRequest 0..255 x IN/OUT direction sweep (#149)\n"
+        "  i2c_fuzz [ops] [seed]        Malformed I2CWFX3/I2CRFX3 only (#154 isolation)\n"
         "  reopen_race_storm            Tight close/reopen storm; device must stay healthy (#143)\n"
         "  two_actor_open               2nd process hammers EP0 while streaming (#143)\n"
         "  soak [hours] [seed] [max] [-q] [--weight NAME=N]...\n"
@@ -5788,6 +5789,11 @@ int main(int argc, char **argv)
 
     } else if (strcmp(cmd, "ep0_sweep") == 0) {
         rc = fuzz_ep0_sweep(&h);                    /* #149 */
+
+    } else if (strcmp(cmd, "i2c_fuzz") == 0) {
+        long n = (argc >= 3) ? (long)parse_num(argv[2]) : 5000;
+        uint64_t seed = (argc >= 4) ? (uint64_t)strtoull(argv[3], NULL, 0) : 0;
+        rc = fuzz_i2c(&h, n, seed);                 /* #154 isolation */
 
     } else if (strcmp(cmd, "soak") == 0) {
         /* Pass &h so soak_try_reacquire() (which closes and replaces

--- a/tests/fx3_fuzz.c
+++ b/tests/fx3_fuzz.c
@@ -650,6 +650,103 @@ int fuzz_ep0_sweep(libusb_device_handle **h_inout)
 }
 
 /* ------------------------------------------------------------------ */
+/* i2c_fuzz — #154 isolation: malformed I2C only (correct direction)  */
+/* ------------------------------------------------------------------ */
+
+/* Fire only I2CWFX3 (OUT) / I2CRFX3 (IN) with the CORRECT direction but a
+ * random I2C address (wValue), register (wIndex), length, and payload — the
+ * one thing protocol_fuzz does that dir_mismatch/ep0_sweep don't.  If this
+ * alone wedges EP0, it isolates the I2C path as the #154 vector (a malformed
+ * multi-byte transfer hanging I2cTransfer, which runs inside the EP0 handler).
+ * The host bias to address 0xC0 (the Si5351) matches protocol_fuzz so this
+ * reproduces the conditions that wedged at op ~2432.
+ *
+ * Note: this scribbles the Si5351 — a PASS means "I2C abuse did not wedge EP0"
+ * (the clock is still likely corrupted; reload before streaming).  A FAIL is
+ * the #154 wedge reproduced in isolation. */
+static void i2c_fuzz_step(libusb_device_handle *h, struct fuzz_rng *rng,
+                          struct fuzz_log *log)
+{
+    int is_read = fuzz_below(rng, 2);
+    uint8_t code = is_read ? I2CRFX3 : I2CWFX3;
+    uint8_t dir  = is_read ? LIBUSB_ENDPOINT_IN : LIBUSB_ENDPOINT_OUT; /* correct */
+    uint8_t bmrt = dir | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE;
+
+    /* wValue = I2C device address, wIndex = register (firmware:
+     * I2cTransfer(wIndex, wValue, wLength, ...)).  35% snap to the Si5351. */
+    uint16_t addr = (fuzz_below(rng, 100) < 35) ? 0x00C0
+                                                : (uint16_t)fuzz_below(rng, 0x10000);
+    uint16_t reg  = (uint16_t)fuzz_below(rng, 0x10000);
+
+    /* Length <= 64 (no oversize — keep it past the wLength>64 STALL so
+     * I2cTransfer actually runs), weighted toward small + multi-byte. */
+    uint16_t wLength;
+    uint32_t wsel = fuzz_below(rng, 100);
+    if      (wsel < 20) wLength = 0;
+    else if (wsel < 50) wLength = 1;
+    else if (wsel < 80) wLength = (uint16_t)(2 + fuzz_below(rng, 7));   /* 2..8 */
+    else                wLength = (uint16_t)(1 + fuzz_below(rng, 64));  /* 1..64 */
+
+    static uint8_t buf[64];
+    uint16_t plen = wLength <= sizeof(buf) ? wLength : (uint16_t)sizeof(buf);
+    for (uint16_t i = 0; i < plen; i++) buf[i] = (uint8_t)fuzz_next(rng);
+
+    int rc = libusb_control_transfer(h, bmrt, code, addr, reg, buf, plen, 250);
+    struct fuzz_op op = { bmrt, code, addr, reg, wLength, plen, rc };
+    fuzz_record(log, &op, 0);
+}
+
+int fuzz_i2c(libusb_device_handle **h_inout, long num_ops, uint64_t seed)
+{
+    libusb_device_handle *h = *h_inout;
+    if (num_ops <= 0) num_ops = 5000;
+    seed = fuzz_seed_or_time(seed);
+    struct fuzz_rng rng = { seed };
+    struct fuzz_log log; fuzz_log_init(&log);
+
+    fuzz_stop = 0;
+    signal(SIGINT, fuzz_sigint);
+    printf("=== I2C_FUZZ === ops=%ld seed=0x%016llx "
+           "(I2CWFX3/I2CRFX3 only, correct direction, random addr/reg/len)\n",
+           num_ops, (unsigned long long)seed);
+
+    uint32_t boot = 0;
+    if (fuzz_gate(&h, &log, &boot, /*quiet=*/0) != 0) {
+        printf("FAIL i2c_fuzz: device unhealthy before start\n");
+        signal(SIGINT, SIG_DFL);
+        *h_inout = h;
+        return 1;
+    }
+
+    int rc = 0;
+    for (long i = 0; i < num_ops && !fuzz_stop; i++) {
+        i2c_fuzz_step(h, &rng, &log);
+        if ((i + 1) % 64 == 0) {
+            int hc = fuzz_gate(&h, &log, &boot, /*quiet=*/0);
+            if (hc != 0) {
+                printf("FAIL i2c_fuzz: health gate failed at op %ld (%s) — "
+                       "malformed I2C alone wedged EP0 (#154 confirmed)\n",
+                       i + 1, hc == FUZZ_HWCONFIG_BAD ? "hwconfig changed"
+                                                      : libusb_strerror(hc));
+                fuzz_dump(&log, seed, "i2c_fuzz", h);
+                rc = 1;
+                break;
+            }
+        }
+    }
+
+    if (h) cmd_u32(h, STOPFX3, 0);
+    signal(SIGINT, SIG_DFL);
+    fuzz_coverage_report(&log);
+    if (rc == 0)
+        printf("PASS i2c_fuzz: %llu I2C ops, EP0 survived (#154 not reproduced "
+               "by I2C alone). NOTE: Si5351 likely reconfigured — reload before "
+               "streaming.\n", (unsigned long long)log.seq);
+    *h_inout = h;
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
 /* stream_fuzz — async bulk + host-lifecycle fuzzer                   */
 /* ------------------------------------------------------------------ */
 #define SF_POOL 8

--- a/tests/fx3_fuzz.c
+++ b/tests/fx3_fuzz.c
@@ -747,6 +747,77 @@ int fuzz_i2c(libusb_device_handle **h_inout, long num_ops, uint64_t seed)
 }
 
 /* ------------------------------------------------------------------ */
+/* oversend_fuzz — #154 isolation: short-wLength on fixed-size IN      */
+/* responders (GETSTATS=30, TESTFX3=4, READINFODEBUG=len+1) that ignore*/
+/* wLength and over-send when the host requests fewer bytes.           */
+/* ------------------------------------------------------------------ */
+int fuzz_oversend(libusb_device_handle **h_inout, long num_ops, uint64_t seed)
+{
+    libusb_device_handle *h = *h_inout;
+    if (num_ops <= 0) num_ops = 5000;
+    seed = fuzz_seed_or_time(seed);
+    struct fuzz_rng rng = { seed };
+    struct fuzz_log log; fuzz_log_init(&log);
+
+    fuzz_stop = 0;
+    signal(SIGINT, fuzz_sigint);
+    printf("=== OVERSEND_FUZZ === ops=%ld seed=0x%016llx "
+           "(GETSTATS/TESTFX3/READINFODEBUG, correct IN dir, wLength < payload)\n",
+           num_ops, (unsigned long long)seed);
+
+    /* Enable debug mode so READINFODEBUG has output queued (len+1 > 1). */
+    { uint8_t info[4]; ctrl_read(h, TESTFX3, 1, 0, info, 4); }
+
+    uint32_t boot = 0;
+    if (fuzz_gate(&h, &log, &boot, /*quiet=*/0) != 0) {
+        printf("FAIL oversend_fuzz: device unhealthy before start\n");
+        signal(SIGINT, SIG_DFL);
+        *h_inout = h;
+        return 1;
+    }
+
+    /* The fixed-size over-senders (I2CRFX3 is excluded — it honours wLength). */
+    static const uint8_t responders[] = { GETSTATS, TESTFX3, READINFODEBUG };
+
+    int rc = 0;
+    static uint8_t buf[64];
+    for (long i = 0; i < num_ops && !fuzz_stop; i++) {
+        uint8_t code = responders[fuzz_below(&rng, 3)];
+        /* wLength 0..3 — below TESTFX3's 4 and far below GETSTATS's 30, so the
+         * handler's fixed SendEP0Data over-sends past what the host asked. */
+        uint16_t wLength = (uint16_t)fuzz_below(&rng, 4);
+        uint8_t bmrt = LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR
+                     | LIBUSB_RECIPIENT_DEVICE;
+        int r = libusb_control_transfer(h, bmrt, code, 0, 0, buf, wLength, 250);
+        struct fuzz_op op = { bmrt, code, 0, 0, wLength, wLength, r };
+        fuzz_record(&log, &op, 0);
+
+        if ((i + 1) % 64 == 0) {
+            int hc = fuzz_gate(&h, &log, &boot, /*quiet=*/0);
+            if (hc != 0) {
+                printf("FAIL oversend_fuzz: health gate failed at op %ld (%s) — "
+                       "short-wLength over-send alone wedged EP0 (#154 confirmed)\n",
+                       i + 1, hc == FUZZ_HWCONFIG_BAD ? "hwconfig changed"
+                                                      : libusb_strerror(hc));
+                fuzz_dump(&log, seed, "oversend_fuzz", h);
+                rc = 1;
+                break;
+            }
+        }
+    }
+
+    if (h) cmd_u32(h, STOPFX3, 0);
+    signal(SIGINT, SIG_DFL);
+    fuzz_coverage_report(&log);
+    if (rc == 0)
+        printf("PASS oversend_fuzz: %llu over-send ops, EP0 survived "
+               "(#154 not reproduced by over-send alone)\n",
+               (unsigned long long)log.seq);
+    *h_inout = h;
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
 /* stream_fuzz — async bulk + host-lifecycle fuzzer                   */
 /* ------------------------------------------------------------------ */
 #define SF_POOL 8

--- a/tests/fx3_fuzz.c
+++ b/tests/fx3_fuzz.c
@@ -275,6 +275,12 @@ static volatile sig_atomic_t fuzz_stop;
 static void fuzz_sigint(int sig) { (void)sig; fuzz_stop = 1; }
 
 /* Build and send one random EP0 control transfer, recording it. */
+/* #154 bisection knobs (env vars): subtract one command class / recipient
+ * fuzzing from protocol_fuzz to find which is necessary for the op-2432 wedge.
+ * Excluded classes are remapped to TESTFX3 so the RNG stream stays identical
+ * (a clean A/B against the unmodified run). */
+static int g_fuzz_no_stream, g_fuzz_no_i2c, g_fuzz_device_only;
+
 static void protocol_fuzz_step(libusb_device_handle *h, struct fuzz_rng *rng,
                                struct fuzz_log *log, int streaming)
 {
@@ -286,6 +292,11 @@ static void protocol_fuzz_step(libusb_device_handle *h, struct fuzz_rng *rng,
         br = (uint8_t)fuzz_below(rng, 256);
     /* Remap destructive codes away so the default run is non-destructive. */
     if (br == RESETFX3 || br == HANGFX3 || br == HANGMAIN)
+        br = TESTFX3;
+    /* Bisection knobs: remap the excluded class to a benign TESTFX3. */
+    if (g_fuzz_no_stream && (br == STARTFX3 || br == STARTADC || br == STOPFX3))
+        br = TESTFX3;
+    if (g_fuzz_no_i2c && (br == I2CWFX3 || br == I2CRFX3))
         br = TESTFX3;
 
     /* bmRequestType: fully fuzz the DIRECTION (IN/OUT) and RECIPIENT
@@ -303,6 +314,7 @@ static void protocol_fuzz_step(libusb_device_handle *h, struct fuzz_rng *rng,
     uint8_t dir   = fuzz_below(rng, 2) ? LIBUSB_ENDPOINT_IN : LIBUSB_ENDPOINT_OUT;
     uint8_t recip = fuzz_below(rng, 100) < 70 ? LIBUSB_RECIPIENT_DEVICE
                                               : (uint8_t)fuzz_below(rng, 4);
+    if (g_fuzz_device_only) recip = LIBUSB_RECIPIENT_DEVICE;  /* bisection knob */
     uint8_t bmrt  = dir | LIBUSB_REQUEST_TYPE_VENDOR | recip;
 
     uint16_t wValue = (uint16_t)fuzz_below(rng, 0x10000);
@@ -354,11 +366,19 @@ static int protocol_fuzz_core(libusb_device_handle **h_inout, long num_ops,
     struct fuzz_rng rng = { seed };
     struct fuzz_log log; fuzz_log_init(&log);
 
+    /* #154 bisection knobs (env). */
+    g_fuzz_no_stream   = getenv("RX888_FUZZ_NO_STREAM")   != NULL;
+    g_fuzz_no_i2c      = getenv("RX888_FUZZ_NO_I2C")      != NULL;
+    g_fuzz_device_only = getenv("RX888_FUZZ_DEVICE_ONLY") != NULL;
+
     if (!quiet) {
         fuzz_stop = 0;
         signal(SIGINT, fuzz_sigint);
-        printf("=== PROTOCOL_FUZZ === ops=%ld seed=0x%016llx\n",
-               num_ops, (unsigned long long)seed);
+        printf("=== PROTOCOL_FUZZ === ops=%ld seed=0x%016llx%s%s%s\n",
+               num_ops, (unsigned long long)seed,
+               g_fuzz_no_stream   ? " [NO_STREAM]"   : "",
+               g_fuzz_no_i2c      ? " [NO_I2C]"      : "",
+               g_fuzz_device_only ? " [DEVICE_ONLY]" : "");
     }
 
     uint32_t boot = 0;

--- a/tests/fx3_fuzz.h
+++ b/tests/fx3_fuzz.h
@@ -37,6 +37,10 @@ int fuzz_ep0_sweep(libusb_device_handle **h_inout);
  * addr/reg/len) — confirms whether the I2C path alone wedges EP0. */
 int fuzz_i2c(libusb_device_handle **h_inout, long num_ops, uint64_t seed);
 
+/* #154 isolation: short-wLength requests to the fixed-size IN responders
+ * (GETSTATS/TESTFX3/READINFODEBUG) that over-send past wLength. */
+int fuzz_oversend(libusb_device_handle **h_inout, long num_ops, uint64_t seed);
+
 /* #148: the standalone fuzzers return 2 when the device is EP0-healthy but no
  * longer streaming (Si5351 likely reconfigured by fuzz); main() maps that to a
  * reload-and-re-verify recovery check. */

--- a/tests/fx3_fuzz.h
+++ b/tests/fx3_fuzz.h
@@ -33,6 +33,10 @@ int fuzz_dir_mismatch(libusb_device_handle **h_inout, long num_ops, uint64_t see
  * survives — the regression test for the #142 direction guard. */
 int fuzz_ep0_sweep(libusb_device_handle **h_inout);
 
+/* #154 isolation: malformed I2CWFX3/I2CRFX3 only (correct direction, random
+ * addr/reg/len) — confirms whether the I2C path alone wedges EP0. */
+int fuzz_i2c(libusb_device_handle **h_inout, long num_ops, uint64_t seed);
+
 /* #148: the standalone fuzzers return 2 when the device is EP0-healthy but no
  * longer streaming (Si5351 likely reconfigured by fuzz); main() maps that to a
  * reload-and-re-verify recovery check. */


### PR DESCRIPTION
**Merged** — closes #154. Includes both the Phase 0 isolation tooling and the Phase 1 firmware fix.

After the #142 direction guard, `protocol_fuzz` still wedged EP0 (~op 2432, seed 1) while `dir_mismatch`/`ep0_sweep` were clean — a non-direction vector. The suspect was the I2C path: `protocol_fuzz` fires `I2CWFX3`/`I2CRFX3` with random address/register/multi-byte length, and `I2cTransfer()` runs *inside* the EP0 handler (`USBHandler.c`), so a hung transfer blocks EP0.

## Phase 0 — build-free isolation (host tooling)
`fx3_cmd i2c_fuzz [ops] [seed]` plus the `protocol_fuzz` bisection knobs (`RX888_FUZZ_NO_STREAM` / `NO_I2C` / `DEVICE_ONLY`) and `oversend_fuzz`. Subtractive bisection on hardware confirmed: I2C is necessary (`NO_I2C` → no wedge) and the wedge is the EP0 handler hanging (`NO_STREAM` → wedge with watchdog resets).

## Phase 1 — firmware fix (the merged change)
`SDDC_FX3/i2cmodule.{c,h}`: `i2cConfig.busTimeout` changed from `0xFFFFFFFF` (~10.6 s at the 403.2 MHz core clock) to a finite `I2C_BUS_TIMEOUT` = 4,032,000 core clocks (~10 ms). A stranded/clock-stretched bus can no longer block the EP0 vendor handler past the Level-4 handler-liveness budget (2 s). Failures still bump `glCounter[1]` (i2c_failures) and now return promptly instead of stalling. No firmware version bump (held at 2.6).

## Hardware validation
`i2c_fuzz 5000 <seed>` passes with `resets=0` and `I2CRFX3 err` climbing — malformed reads return an error instead of stranding the bus (pre-fix this path could hang). `fw_test` 43/43. The I2C-alone wedge mechanism #154 diagnosed is closed.

## Residuals (tracked separately)
The fix moved the full-mix `protocol_fuzz` wedge from op ~2432 → ~3584 but did not eliminate it:
- **#157** — the residual wedge requires *both* I2C and active streaming (`wedge ⟺ I2C ∧ stream`); a distinct stream∧I2C interaction.
- **#160** — `Si5351Init()` leaves clock-gating registers unwritten, so wrong I2C writes can brick the clock until a power cycle.

https://claude.ai/code/session_01XLg8ToK3L8DhoV4QWtFMae

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLg8ToK3L8DhoV4QWtFMae)_