### PR TITLE
fw: RX888mk2 I2C/clock robustness — hardcode RX888r2 (#158) + restore Si5351 clock-gating registers (#160)

### DIFF
--- a/SDDC_FX3/RunApplication.c
+++ b/SDDC_FX3/RunApplication.c
@@ -152,62 +152,32 @@ void ApplicationThread ( uint32_t input)
 	int32_t Seconds = 0;  // second count in serial debug
 #endif
 	uint32_t nline;
-	CyBool_t measure;
     CyU3PReturnStatus_t Status;
-    glHWconfig = 0;
+
+    /* RX888mk2-only firmware: the hardware model is fixed.  The previous
+     * boot-time autodetect probed the R828D tuner over I2C and fell back to
+     * NORADIO on any failure, so a disturbed or corrupted I2C bus could
+     * silently brick the device into a non-streaming state that a firmware
+     * reload could not clear (only a power cycle could).  Hardcode the model
+     * and bring up the clock unconditionally: a failed Si5351 init no longer
+     * blocks enumeration, and a later STARTADC re-establishes the sample
+     * clock.  See issue #158. */
+    glHWconfig = RX888r2;
 
     GpioInitClock();
 
-	DebugPrint(4, "Detect Hardware");
     Status = I2cInit ();
     if (Status != CY_U3P_SUCCESS)
-    	DebugPrint(4, "I2cInit failed to initialize. Error code: %d.", Status);
-	else
-	{
-		Status = Si5351Init();
-		if (Status != CY_U3P_SUCCESS)
-		{
-			DebugPrint(4, "Si5351Init failed to initialize. Error code: %d.", Status);
-		}
-		else
-		{
-			ConfGPIOsimpleinputPU(GPIO36);
-
-			Status = si5351aSetFrequencyB(16000000);
-			if (Status != CY_U3P_SUCCESS)
-				DebugPrint(4, "si5351aSetFrequencyB(16MHz) failed: %d.", Status);
-			uint8_t identity;
-			if (I2cTransfer(0, R828D_I2C_ADDR, 1, &identity, true) == CY_U3P_SUCCESS)
-			{
-				CyU3PGpioSimpleGetValue ( GPIO36, &measure);
-
-				if (!measure)
-				{
-					glHWconfig = RX888r2;
-					DebugPrint(4, "R828D detected. RX888r2 detected.");
-				}
-				else
-				{
-					glHWconfig = NORADIO;
-					DebugPrint(4, "R828D detected but GPIO36 sense failed.");
-				}
-			}
-			else
-			{
-				glHWconfig = NORADIO;
-				DebugPrint(4, "No R828D tuner detected.");
-			}
-			Status = si5351aSetFrequencyB(0);
-			if (Status != CY_U3P_SUCCESS)
-				DebugPrint(4, "si5351aSetFrequencyB(0) failed: %d.", Status);
-		}
-	}
+        DebugPrint(4, "I2cInit failed to initialize. Error code: %d.", Status);
+    else
+    {
+        Status = Si5351Init();
+        if (Status != CY_U3P_SUCCESS)
+            DebugPrint(4, "Si5351Init failed to initialize. Error code: %d.", Status);
+    }
     DebugPrint(4, "HWconfig: %d.", glHWconfig);
 
-	if (glHWconfig == RX888r2)
-	{
-		rx888r2_GpioInitialize();
-	}
+    rx888r2_GpioInitialize();
 
     // Spin up the USB Connection
 	Status = InitializeUSB(glHWconfig);


### PR DESCRIPTION
Two stacked firmware changes for the RX888mk2 I2C/clock robustness, both on `main` (which already includes #156's busTimeout fix). Closes #158 and #160.

---

## Commit 1 — hardcode RX888r2, drop the R828D-probe autodetect (#158)

`SDDC_FX3/RunApplication.c`: remove the boot-time model autodetect (R828D I2C read at 0x74, GPIO36 sense, NORADIO fallbacks, 16 MHz/0 probe-clock) and set `glHWconfig = RX888r2` unconditionally. `I2cInit()`/`Si5351Init()` still run but no longer gate the model; `rx888r2_GpioInitialize()` runs unconditionally.

**Why:** this is an RX888mk2-only firmware; the probe's only functional effect was gating GPIO init (`SetUSBdescriptors` ignores its `hwconfig` arg), and its failure mode bricked the device into a non-streaming `NORADIO` state a reload couldn't clear. Removes the boot-time I2C dependency and that brick mode. `hwconfig` still reports `0x04`.

## Commit 2 — Si5351Init restores clock-gating registers (#160)

`SDDC_FX3/driver/Si5351.c`: `Si5351Init()` previously wrote only the crystal load cap + three CLK power-downs. It now also restores the clock-gating/routing registers to AN619 power-on defaults:

| Reg | Field | Value |
|---|---|---|
| 15 | PLL Input Source | `0x00` (PLLA/B ← XTAL) |
| 9 | OEB Pin Enable Mask | `0x00` |
| 3 | Output Enable Control | `0x00` |
| 24 / 25 | CLK Disable State | `0x00` |
| 187 | Fanout Enable | `0xD0` |

**Why:** these registers were never written, so a wrong I2C write to any of them — from the destructive fuzzers **or a host driver miscomputing a value over I2CWFX3** — bricked the clock with no firmware recovery (power cycle only). Per AN619, reg 187's reset value is **undefined** and its CLKIN/XO/**MS** fanout bits (7/6/4) must be 1 — MS_FANOUT_EN gates MultiSynth0 → the output mux (the ADC clock), so the firmware had been relying on the part's undefined power-on state. Now a `reload` returns the Si5351 to a known-good state regardless of corruption, and a subsequent `STARTADC` re-establishes the clock without a power cycle.

Together: #158 ensures the device re-enumerates correctly after I2C disturbance; #160 ensures the clock state is actually restored. Both are needed for full self-recovery on a reload.

No firmware version bump (held at 2.6).

## Validation (hardware — firmware is CI-built)
- `./fw_test.sh --firmware "$FW"` → `hwconfig=0x04`, 43/43 (incl. PLL-lock + stream).
- `./validate.sh --firmware "$FW" --stages 3` → real Si5351 tuning + streaming.
- Surgical #160 repro: `I2CWFX3 reg 3=0xFF` (or `reg 187=0x00`) → `reload` → `STARTADC` now streams (pre-fix: power cycle required).
- The added Si5351 writes are AN619 defaults / datasheet-mandated bits — the state a healthy power-cycled part already has — so a working device is unaffected.

## Scope notes
- Built on `main` (incl. #156 busTimeout). The dead `hwconfig` param on `InitializeUSB`/`SetUSBdescriptors` is intentionally left in place to keep the diffs minimal.
- Residual `protocol_fuzz` full-mix wedge is tracked separately in #157.

https://claude.ai/code/session_01XLg8ToK3L8DhoV4QWtFMae

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLg8ToK3L8DhoV4QWtFMae)_