### PR TITLE
test(setarg_gap_index): tolerate transient EP0 STALL on survival check (#111)

### DIFF
--- a/tests/fx3_cmd.c
+++ b/tests/fx3_cmd.c
@@ -3108,9 +3108,14 @@ static int do_test_setarg_gap_index(libusb_device_handle *h)
         /* Either STALL or accept is fine — just no crash */
     }
 
-    /* Verify alive */
-    uint8_t info[4] = {0};
-    int r = ctrl_read(h, TESTFX3, 0, 0, info, 4);
+    /* Verify alive.  The final gap probe STALLs EP0 (expected); the FX3 can
+     * race the stall auto-clear, so this survival check — the very next SETUP —
+     * can see a transient LIBUSB_ERROR_PIPE on a device that is alive and
+     * answers the next request.  Tolerate and retry, exactly as the #135
+     * scenarios do.  This was the ~5.9% setarg_gap_index intermittent (#111);
+     * the per-probe loop above already accepts PIPE, so the survival check was
+     * the only spot that turned the transient stall into a false failure. */
+    int r = ep0_alive_after_stall(h);
     if (r < 0) {
         int have_after = (read_stats(h, &after) == 0);
         printf("FAIL setarg_gap_index: device unresponsive: %s\n",


### PR DESCRIPTION
## Summary

Fixes the ~5.9% intermittent in the `setarg_gap_index` test (#111).

`do_test_setarg_gap_index` probes `SETARGFX3` with out-of-range `wIndex` values `{12,13,15}`; the firmware STALLs each (the expected, accepted outcome). The final probe (`wIndex=15`) STALLs EP0, and the post-probe `TESTFX3` survival check is the **very next SETUP packet**. A control endpoint auto-clears its stall on the next SETUP, but the FX3 occasionally races that clear, so the check sees a transient `LIBUSB_ERROR_PIPE` on a device that is alive and answers the next request.

This is the identical mechanism root-caused and fixed for `oob_setarg` / `i2c_write_bad_addr` in #135. The per-probe loop already accepts `PIPE`, so the survival check was the only spot turning the transient stall into a false failure.

## Change

`tests/fx3_cmd.c` — replace the raw post-probe survival read with the existing, proven `ep0_alive_after_stall()` helper (`tests/fx3_usb.c`), which retries `TESTFX3` up to 3× on `PIPE` with 2/4/8 ms backoff. No firmware change — this is a test-side timing false-positive, not a device hang.

**Safety:** `ep0_alive_after_stall` only retries on `PIPE`; a genuine wedge (`TIMEOUT`/`IO`/`NO_DEVICE`) still fails every attempt, so the fix cannot mask a real hang.

## Validation (needs bench)

```sh
for i in $(seq 1 100); do ./fx3_cmd setarg_gap_index 2>&1 | grep -E "^(PASS|FAIL|#)"; done
```
Previously expected ~5–6 failures; now expect **0/100**. Also covered by `./fx3_cmd soak 2`.

## Build

Identical to the documented test build: `cd tests && make fx3_cmd`. Confirmed clean under `-Wall -Wextra`, no warnings (the removed `info[4]` produces no unused-variable complaint).

Fixes #111

https://claude.ai/code/session_011cGmvB85bFgMZFAN34h5mZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011cGmvB85bFgMZFAN34h5mZ)_