### PR TITLE
Safer probing: validate snapshots, guard on failed reads, and report scan writes

### DIFF
--- a/r828d_probe.py
+++ b/r828d_probe.py
@@ -137,6 +137,8 @@ class Tuner:
 
     def save_snapshot(self, path, label=""):
         regs = self.read_all()
+        if len(regs) != 0x20:
+            sys.exit(f"snapshot failed: captured {len(regs)} registers, expected 32")
         with open(path, "w") as f:
             f.write("# r828d snapshot — WIRE order "
                     "(bit-reversed from Rafael logical numbering; wire b_w = logical b_7-w)\n")
@@ -194,10 +196,11 @@ class Tuner:
                 print("  could not determine the wrap window from a 64-byte read.")
             print("  skipping write-probe: in from0 mode a write to 0x20+ wraps "
                   "onto the low registers (clobber risk).")
-            return
+            return False
 
         print(f"\n=== scan 0x{start:02X}..0x{end:02X} for undocumented registers ===")
         base = self.rd_block(0x00, 0x1F)               # for wrap detection
+        wrote = False
         for reg in range(start, end + 1):
             v = self.rd(reg)
             if v is None:
@@ -206,11 +209,13 @@ class Tuner:
             if wraps:
                 print(f"  reg 0x{reg:02X} = 0x{v:02X}  -> wraps to low map"); continue
             orig = v
+            wrote = True
             self.i2c_w(reg, [orig ^ 0xFF]); rb = self.rd(reg)
             self.i2c_w(reg, [orig])
             holds = rb is not None and rb != orig
             print(f"  reg 0x{reg:02X} = 0x{v:02X}  -> "
                   f"{'HOLDS a write!' if holds else 'static'}")
+        return wrote
 
     def reinit(self):
         """Restore the documented init defaults (sane post-probe state)."""
@@ -323,8 +328,11 @@ def main():
     t = Tuner()
     t.alive()
     t.characterize_reads()
-    if t.rd(0x00) != 0x69:
-        sys.exit(f"reg 0x00 != 0x69 (got 0x{t.rd(0x00):02X}) — not an R828D / not reachable; "
+    idv = t.rd(0x00)
+    if idv is None:
+        sys.exit("reg 0x00 read failed — not an R828D / not reachable; refusing to write")
+    if idv != 0x69:
+        sys.exit(f"reg 0x00 != 0x69 (got 0x{idv:02X}) — not an R828D / not reachable; "
                  "refusing to write")
 
     if args.snapshot:
@@ -336,7 +344,7 @@ def main():
     if args.settability or args.all:
         t.settability(0x00, 0x1F); wrote = True
     if args.scan or args.all:
-        t.scan(); wrote = True
+        wrote = t.scan() or wrote
 
     if wrote and not args.no_reinit:
         t.reinit()


### PR DESCRIPTION
### Motivation
- Prevent destructive writes when the device is unreachable or a read fails, and make probing behavior explicit when reads wrap in `from0` mode.
- Ensure `save_snapshot` writes only complete 32-register snapshots to avoid misleading files.
- Propagate whether `scan` actually performed writes so `main` can decide whether to `reinit`.

### Description
- `save_snapshot` now checks that `read_all()` returned 32 registers and exits with an error if not. 
- `scan` returns `False` early in `from0` read mode, tracks whether it performed any write-probes, and returns a boolean `wrote` indicating if writes occurred. 
- `main` now checks `t.rd(0x00)` for `None` and exits with a clear error if the chip ID read failed, and uses `scan()`'s return value to update the `wrote` flag.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b027dcd8883219dd8b614d0300419)