### PR TITLE
Add enforced bug-report and feature-request issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,181 @@
+name: Bug report
+description: Report a reproducible firmware defect. Required fields must be filled before the issue can be filed.
+title: "[BUG] <short, specific summary>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Read this first
+
+        This is **FX3 firmware for the RX888 mk2**, not a host application,
+        not an antenna, and not your USB cable. Before you file:
+
+        - **"It doesn't work" is not a bug report.** Tell us what you did,
+          what you expected, and what actually happened — separately.
+        - **Reproduce it.** If it happened once and never again, open a
+          Discussion, not an issue.
+        - **Isolate the firmware.** A lot of "firmware bugs" are host
+          config, RF front-end, clocking, or power. The fields below exist
+          so we don't spend a week discovering it was your hub.
+        - Every required field below must be answered. Forms with the
+          required fields blank cannot be submitted, and issues that gut
+          the template will be closed without triage.
+
+        If you can build the firmware, the maintainers expect you to have
+        already read `README.md` and `docs/`.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      description: All of these must be true. Tick each one only after you have actually done it.
+      options:
+        - label: I searched existing open AND closed issues and this is not a duplicate.
+          required: true
+        - label: I have reproduced this deterministically (I can make it happen on demand).
+          required: true
+        - label: I confirmed the failure is in THIS firmware, not the host app, RF front-end, power supply, or USB cabling/hub.
+          required: true
+        - label: I am not asking for R828D / VHF tuner support — the firmware is HF direct-sampling only (see README "Limitations").
+          required: true
+
+  - type: input
+    id: firmware-version
+    attributes:
+      label: Firmware version
+      description: >
+        The version REPORTED BY THE DEVICE via the `TESTFX3` vendor command
+        (FIRMWARE_VER_MAJOR.FIRMWARE_VER_MINOR), e.g. `2.6`. Not the repo tag,
+        not "latest", not "the one from the website". If you cannot read it,
+        say so and explain why.
+      placeholder: "e.g. 2.6 (TESTFX3 reported)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: firmware-provenance
+    attributes:
+      label: Where did this firmware come from?
+      options:
+        - Official release artifact (SDDC_FX3.img from the Releases page)
+        - Built from this repo with arm-none-eabi-gcc (give commit + toolchain version below)
+        - Built from a fork / patched source (you must link it below)
+        - I don't know
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: build-provenance
+    attributes:
+      label: Commit / release tag / toolchain
+      description: >
+        If you built it: the exact commit SHA and `arm-none-eabi-gcc --version`.
+        If it's a release: the release tag. "main" is not an answer; give the SHA.
+      placeholder: "e.g. release v2.6.1  —  or  —  commit a1b2c3d, arm-none-eabi-gcc 13.2.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: usb-state
+    attributes:
+      label: USB enumeration state when the bug occurs
+      description: Check with `lsusb`. This tells us whether the FX3 is in bootloader, app, or wedged.
+      options:
+        - "04b4:00f3 — bootloader (firmware not yet loaded)"
+        - "04b4:00f1 — application (firmware running)"
+        - "Device disappears / not enumerated at all"
+        - "Other VID:PID (paste it in the logs section)"
+        - "I did not check"
+      default: 4
+    validations:
+      required: true
+
+  - type: textarea
+    id: host-environment
+    attributes:
+      label: Host environment
+      description: >
+        OS + version, host application + version (ka9q-radio, rx888_tools/rx888_stream,
+        ExtIO host, etc.), and how the device is connected (direct port vs hub,
+        USB 2 vs 3). If you're using ka9q-radio, include the relevant radiod config.
+      placeholder: |
+        OS: Debian 12 (kernel 6.x)
+        Host app: ka9q-radio <commit/version>, or rx888_stream from rx888_tools <version>
+        Connection: rear USB3 port, no hub
+        radiod config (if relevant): ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact, numbered, copy-pasteable. Include the actual commands you ran.
+      placeholder: |
+        1. Flash SDDC_FX3.img with `rx888_stream ...`
+        2. Start `radiod ...` (or `rx888_stream ...`)
+        3. Tune to X MHz at Y Msps
+        4. After ~Z seconds ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      placeholder: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened. Be precise — "no signal" vs "stream stalls" vs "device drops off the bus" are completely different bugs.
+      placeholder: What actually happened, including any error messages verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and evidence
+      description: >
+        Paste `dmesg` USB output, host-app logs, `lsusb -v` if relevant, and any
+        TESTFX3 device-info dump. Use code fences. Screenshots of a terminal are
+        not logs — paste the text.
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: recoverable
+    attributes:
+      label: Does the device recover without a power cycle?
+      description: >
+        A core design principle is that no state should require a power cycle to
+        recover (RESETFX3 / STOPFX3 should always work). This answer matters.
+      options:
+        - "Yes — RESETFX3/STOPFX3 or re-enumeration recovers it"
+        - "No — it requires a physical power cycle"
+        - "Not applicable / didn't try"
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried to isolate it?
+      description: >
+        Different cable/port/host? A known-good release artifact vs your build?
+        Lower sample rate? This is where you prove it's the firmware and not
+        your setup. "Nothing" is an acceptable answer only if you explain why.
+      placeholder: |
+        - Swapped to a rear USB3 port directly on the board: still fails
+        - Tried official v2.6.1 release artifact: also fails / works fine
+        - Dropped sample rate from X to Y: ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
           required: true
         - label: I confirmed the failure is in THIS firmware, not the host app, RF front-end, power supply, or USB cabling/hub.
           required: true
-        - label: I am not asking for R828D / VHF tuner support — the firmware is HF direct-sampling only (see README "Limitations").
+        - label: This is a defect report, not a request for VHF tuning — the firmware is HF direct-sampling (R828D control, if any, is limited to simple init/standby; see README "Limitations").
           required: true
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,8 +7,10 @@ contact_links:
     about: >
       Not sure it's a firmware defect? Tuning, antenna, host-app, clocking,
       or power questions belong in Discussions, not the bug tracker.
-  - name: R828D / VHF tuner support
+  - name: R828D / VHF tuner scope
     url: https://github.com/ringof/rx888-firmware#limitations
     about: >
-      This firmware is HF direct-sampling only. The R828D VHF tuner is not
-      driven by the firmware — read the README "Limitations" section first.
+      The firmware is HF direct-sampling. Simple bounded R828D control (init,
+      standby) can be proposed as a feature request with a good argument; full
+      VHF tuning belongs in a host-side driver. Read the README "Limitations"
+      first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Force reporters through the structured templates — no blank issues that
+# bypass the required fields.
+blank_issues_enabled: false
+contact_links:
+  - name: Question, "is this a bug?", or RF/host-config help
+    url: https://github.com/ringof/rx888-firmware/discussions
+    about: >
+      Not sure it's a firmware defect? Tuning, antenna, host-app, clocking,
+      or power questions belong in Discussions, not the bug tracker.
+  - name: R828D / VHF tuner support
+    url: https://github.com/ringof/rx888-firmware#limitations
+    about: >
+      This firmware is HF direct-sampling only. The R828D VHF tuner is not
+      driven by the firmware — read the README "Limitations" section first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,10 +18,14 @@ body:
         - **Scope it to the firmware.** Demodulation, channelization, audio,
           waterfalls, and UI belong in the host (ka9q-radio, rx888_tools).
           If it can be done host-side, it should be.
-        - **"Add VHF / R828D tuning" is out of scope.** The firmware is HF
-          direct-sampling only and the GPL R82xx driver was removed for a
-          license conflict (see README "Limitations"). VHF belongs in a
-          host-side driver over the I2C passthrough.
+        - **R828D / VHF requests are limited, not banned.** The firmware is
+          HF direct-sampling and the GPL R82xx driver was removed for a license
+          conflict (see README "Limitations"). **Simple, bounded R828D control
+          — e.g. init and standby/power-down — may be accepted if you make a
+          good case.** Full VHF tuning, gain-stage control, channel filtering,
+          and anything resembling a tuner driver are refused — that belongs in
+          a host-side driver over the I2C passthrough. Tell us which side of
+          that line your request is on, and why.
         - **Justify it.** A feature is a maintenance and recoverability
           liability forever. Tell us the problem, not just the solution.
         - Every required field below must be answered. Requests that gut
@@ -37,7 +41,7 @@ body:
           required: true
         - label: This genuinely belongs in the FIRMWARE — it cannot reasonably be done host-side (ka9q-radio / rx888_tools).
           required: true
-        - label: This is not a request for R828D / VHF tuner support (HF direct-sampling only — see README "Limitations").
+        - label: If this involves the R828D / VHF tuner, it is limited to simple bounded control (e.g. init / standby) — I am NOT asking for VHF tuning, gain-stage, or channel-filter control in firmware (those belong host-side; see README "Limitations").
           required: true
         - label: I have read the relevant docs (`README.md`, `docs/architecture.md`, `docs/vendor-protocol-plan.md`) and this does not already exist.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,133 @@
+name: Feature request
+description: Propose a firmware change or new capability. Required fields must be filled before the request can be filed.
+title: "[FEATURE] <short, specific summary>"
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Read this first
+
+        This is **FX3 firmware for the RX888 mk2** — a USB vendor-command
+        protocol, a GPIF II state machine, a DMA pipeline, and clock control,
+        running on a memory- and MIPS-constrained Cypress FX3. It is **not**
+        a host application and not a DSP framework.
+
+        Before you file:
+
+        - **Scope it to the firmware.** Demodulation, channelization, audio,
+          waterfalls, and UI belong in the host (ka9q-radio, rx888_tools).
+          If it can be done host-side, it should be.
+        - **"Add VHF / R828D tuning" is out of scope.** The firmware is HF
+          direct-sampling only and the GPL R82xx driver was removed for a
+          license conflict (see README "Limitations"). VHF belongs in a
+          host-side driver over the I2C passthrough.
+        - **Justify it.** A feature is a maintenance and recoverability
+          liability forever. Tell us the problem, not just the solution.
+        - Every required field below must be answered. Requests that gut
+          the template will be closed without triage.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      description: All of these must be true. Tick each one only after you have actually done it.
+      options:
+        - label: I searched existing open AND closed issues/discussions and this is not a duplicate.
+          required: true
+        - label: This genuinely belongs in the FIRMWARE — it cannot reasonably be done host-side (ka9q-radio / rx888_tools).
+          required: true
+        - label: This is not a request for R828D / VHF tuner support (HF direct-sampling only — see README "Limitations").
+          required: true
+        - label: I have read the relevant docs (`README.md`, `docs/architecture.md`, `docs/vendor-protocol-plan.md`) and this does not already exist.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: >
+        What can't you do today, and why does it matter? Describe the actual
+        problem and who hits it — not the solution. "I want feature X" is not a
+        motivation; "I cannot do Y because the firmware does Z" is.
+      placeholder: |
+        When I ... the firmware currently ... which means I cannot ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: >
+        Concretely, what should the firmware do? If it touches the USB wire
+        protocol, name the vendor command(s) and payload(s). If it touches
+        clocking, GPIF, DMA, or GPIO, say so.
+      placeholder: |
+        Add/extend vendor command ... with payload ...
+        Affects: protocol.h / GPIF / Si5351 clock / DMA / GPIO map (circle as applicable)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary firmware area affected
+      options:
+        - USB vendor-command protocol (protocol.h / EP0 handlers)
+        - GPIF II state machine
+        - DMA / streaming pipeline
+        - Si5351 / clock control
+        - ADC / front-end control (gain, attenuator, dither/rand)
+        - GPIO map
+        - Recovery / watchdog
+        - Build / tooling / CI
+        - Other (explain in the proposal)
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: recoverability
+    attributes:
+      label: Recoverability impact (Principle 2)
+      description: >
+        No firmware change may leave the RX888 in a state requiring a power
+        cycle to recover (see docs/vendor-protocol-plan.md). Explain how your
+        proposal returns to EP0 idle within bounded time, rejects malformed
+        payloads cleanly, and leaves RESETFX3/STOPFX3 working from any reachable
+        state. If you don't know, say so — but it WILL be evaluated on this.
+      placeholder: |
+        New command validates length/range at EP0 before acting; on bad input
+        it stalls/returns without mutating state; RESETFX3 still works because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >
+        Why can't this be solved host-side? What other approaches did you
+        weigh, and why are they worse? "None" is acceptable only if you explain
+        why there is genuinely no host-side or simpler option.
+      placeholder: |
+        Host-side in ka9q-radio: rejected because ...
+        Simpler firmware approach: rejected because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility impact
+      description: >
+        Does this change the wire protocol or behaviour seen by existing hosts
+        (ka9q-radio, rx888_tools/rx888_stream, ExtIO hosts)? Is it backward
+        compatible? Does it need a firmware-version bump (TESTFX3)?
+      placeholder: |
+        Backward compatible: yes/no, because ...
+        Existing hosts affected: ...
+        Needs FIRMWARE_VER bump: yes/no
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

The repo had detailed PR templates but **no issue templates**, so anyone could file a one-line "it doesn't work." This adds two GitHub **issue forms** (not markdown templates) — forms enforce required fields, so a non-compliant report is blocked at submission time rather than triaged and bounced.

New files:
- `.github/ISSUE_TEMPLATE/bug_report.yml` — enforced bug form
- `.github/ISSUE_TEMPLATE/feature_request.yml` — enforced enhancement form
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false` + contact links routing questions and VHF/R828D requests away from the tracker

## What the forms require

**Bug report** (all required): pre-flight checkboxes (dupe search, deterministic repro, confirmed firmware-not-host/RF/power/cable, not a VHF request); firmware version **as reported by the device via `TESTFX3`** (not the repo tag); firmware provenance + commit/tag + `arm-none-eabi-gcc` version; USB enumeration state (`04b4:00f3` / `04b4:00f1` / gone) from `lsusb`; host environment; numbered repro steps; expected vs actual (split); pasted logs (`render: text`); **recoverability** (power cycle required?); and isolation steps already tried.

**Feature request** (all required): pre-flight (dupe search, can't-be-done-host-side, not VHF, read the docs); problem/motivation; concrete proposal; primary firmware area; **recoverability impact (Principle 2)**; alternatives considered (esp. host-side); compatibility/version impact.

Every field is grounded in real repo facts (`TESTFX3`/`protocol.h`, firmware v2.6, the `04b4:00f1/00f3` IDs, HF-only Limitations, recoverability Principle 2 from `docs/vendor-protocol-plan.md`), per the CLAUDE.md "no speculation" policy.

## Validation

- YAML for all three files parses (`yaml.safe_load`) — verified locally.
- After merge: `…/issues/new/choose` shows "Bug report" and "Feature request", "Open a blank issue" is gone, required-blank submission is rejected by GitHub, and contact links render under the chooser.

## Regression

- Only `.github/ISSUE_TEMPLATE/` files added — no source, build, test, workflow, or PR-template changes. Firmware artifact unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HPZJJc4fvRmVhFCVdKDh6

---
_Generated by [Claude Code](https://claude.ai/code/session_017HPZJJc4fvRmVhFCVdKDh6)_