### PR TITLE
feat(vhf): selectable low/high-side LO injection in tuner + TUI

### DIFF
--- a/docs/sideband-selection-plan.md
+++ b/docs/sideband-selection-plan.md
@@ -1,0 +1,115 @@
+# Plan — Low/High-Side Injection Selection in the VHF TUI
+
+Status: **DRAFT — awaiting approval.** No code changed yet.
+
+## Goal
+
+Let the operator switch the R828D between **high-side** (`LO = RF + IF`, the
+current fixed behavior) and **low-side** (`LO = RF − IF`) injection from the
+`vhf_fm_radio.py` TUI, reprogramming the tuner correctly for the chosen side
+and surfacing the resulting spectral-inversion state so the downstream host
+(ka9q-radio) can be set up to match.
+
+## Why
+
+- Today the driver is hard-wired high-side (`rx888_vhf.py:316`,
+  `lo = rf_hz + self.if_hz`) with the mixer sideband bit statically 0
+  (`0x07 = 0x70` in the init array, `rx888_vhf.py:85`). High-side injection
+  **inverts** the spectrum, which is exactly the stereo/RDS-won't-lock caveat
+  in `vhf_fm_howto.md:148`.
+- Low-side injection produces a **non-inverted** spectrum (fixes that caveat)
+  but moves the image to `RF − 2·IF` (~9.14 MHz below the wanted signal),
+  changing tracking-filter image rejection. So a toggle is a genuine
+  inversion-vs-image-rejection operator lever, not just plumbing.
+
+## Correctness requirement
+
+The LO formula and the mixer sideband bit **must stay in lockstep**. Per
+`tuner_r82xx_explained.md:94–95, 234, 429`: `sideband == 0` ⇒ LO above RF
+(high-side); `0x07` bit 7 is the sideband select. The safest design is to
+recompute the LO **and** write the sideband bit together in one place, every
+tune, so they can never desync.
+
+## Changes
+
+### 1. Driver — `vhf/rx888_vhf.py`
+
+- Add `self.sideband_low = False` state (default `False` = high-side =
+  current behavior; zero behavior change until toggled).
+- Add `set_sideband(low)`:
+  ```python
+  def set_sideband(self, low):
+      # 0x07[7]: 0 = high-side (LO above RF), 1 = low-side. Polarity per
+      # r82xx lineage (explained.md:94); BENCH-CONFIRM on the RX888 mk2.
+      self._wr_mask(0x07, 0x80 if low else 0x00, 0x80)
+  ```
+  Neither `set_mixer_gain` (mask `0x0F`) nor `set_mixer_agc` (mask `0x10`)
+  touches bit 7, so the setting persists across gain/AGC changes.
+- In `r828d_set_freq` (line 316), branch the LO and assert the bit in lockstep:
+  ```python
+  lo = rf_hz - self.if_hz if self.sideband_low else rf_hz + self.if_hz
+  self.set_sideband(self.sideband_low)   # keep 0x07[7] matched to the LO
+  ```
+- Add `inverted` helper: high-side ⇒ inverted; low-side ⇒ non-inverted.
+
+### 2. TUI — `vhf/vhf_fm_radio.py`
+
+- New state `self._sideband_low` (default `False`).
+- New key **`s`** (unused in `on_key`, verified) → `_toggle_sideband()`,
+  cloned from `_toggle_ref` (line 407): set state → `set_sideband` →
+  `calibrate_filter(cal_park)` → `r828d_set_freq(freq)` → status message.
+- Display: extend the Bandwidth/IF line (line 231) with the active side and
+  inversion, e.g. `LO− (spectrum: normal)` / `LO+ (spectrum: INVERTED)`,
+  color-coded (INVERTED in yellow, as a caution).
+- Help text (`HELP_TEXT`, line 60): add `s  toggle LO side (high/low)`.
+
+### 3. Host inversion signal (the "+ host inversion signal" scope)
+
+Honest constraint: the TUI controls the tuner over EP0, while ka9q-radio
+streams the ADC in a **separate process** — there is no in-band metadata
+channel between them, so inversion can't be auto-negotiated. What we *can* do:
+
+- Make inversion **visible** in the TUI (item 2 above) so the operator knows
+  the current state at a glance.
+- Document the downstream action in `vhf/vhf_fm_howto.md`: how to tell
+  ka9q-radio the spectrum is inverted (it has per-channel spectral-inversion
+  handling), and that low-side removes the need for it. Update the line-148
+  caveat to point at the new toggle.
+
+### 4. Optional refinement (flag for approve/trim)
+
+Fuller image-rejection fidelity would also flip the IF filter's asymmetric
+"sharp-corner" companion bits (the `IFA()/IFB()` pairing, `explained.md:233–
+234`) per side. These live in `0x0A`/`0x0B`, which `set_bandwidth` already
+writes (mask `0x0F` / `0xEF`, line 496–497), so it needs careful interaction
+with the bandwidth presets. **Proposed: defer** unless bench testing shows the
+minimal change leaves image rejection unacceptable on one side.
+
+## Validation test (bench)
+
+1. Launch TUI, tune a strong local FM station, confirm `LOCKED`, note audio.
+2. Press `s` → confirm log shows a fresh `LO=… lock=YES` with LO now
+   `RF − IF` (≈9.14 MHz lower than the high-side value), and the display flips
+   to the low-side / non-inverted state.
+3. In ka9q-radio, confirm the station now decodes **without** the host
+   inversion setting (and that stereo/RDS behavior tracks the side).
+4. Toggle back with `s`; confirm return to high-side LO and inverted state.
+5. Read back `0x07` bit 7 via I2C and confirm it matches the displayed side.
+
+## Regression test
+
+- With no `s` press, every value/register write is byte-identical to today
+  (default `sideband_low=False`, LO `RF+IF`, `0x07[7]=0`) — verify by diffing
+  the init + first-tune register trace against a pre-change run.
+- Existing keys (`r`, `b/B`, gains, filters, IF offset, cal park) behave
+  unchanged; `s` interacts cleanly with a subsequent `r`/`b` (side persists
+  across ref and bandwidth changes because `0x07[7]` isn't touched by those
+  paths).
+- `q` standby still powers down cleanly.
+
+## Files touched
+
+- `vhf/rx888_vhf.py` — `set_sideband`, LO branch, state, `inverted` helper.
+- `vhf/vhf_fm_radio.py` — state, `s` handler, display, help text.
+- `vhf/vhf_fm_howto.md` — inversion/host note + line-148 caveat update.
+- (this plan doc)

--- a/vhf/rx888_vhf.py
+++ b/vhf/rx888_vhf.py
@@ -164,6 +164,9 @@ class RX888:
         self.regs = {}            # R828D register shadow (for masked writes)
         self.ref_hz = R828D_REF_HZ   # active R828D reference (CLKB); set by clkb_on
         self.if_hz = IF_CARRIER      # active IF center; set by set_bandwidth
+        self.sideband_low = False    # False = high-side (LO=RF+IF, default);
+                                     # True = low-side (LO=RF-IF). Kept in
+                                     # lockstep with 0x07[7] by r828d_set_freq.
 
     # ── EP0 transport (libusb control transfers) ──────────────────────────
     def _out_u32(self, cmd, value):              # GPIOFX3 / STARTADC payload
@@ -311,13 +314,32 @@ class RX888:
 
     # ── R828D tune (partial port of set_freq64: set_mux + set_pll + input sw) ─
     def r828d_set_freq(self, rf_hz):
-        """LO = RF + IF (low-side). set_mux + set_pll, then the Air-In/Cable1
-        input switch. No harmonic retry (out of VHF scope). True iff PLL locked."""
-        lo = rf_hz + self.if_hz
+        """Tune to rf_hz. High-side injection LO = RF + IF by default; low-side
+        LO = RF - IF when self.sideband_low is set. The mixer sideband bit
+        (0x07[7]) is written here in lockstep with the LO so the image-reject
+        mixer always matches the injection side. set_mux + set_pll, then the
+        Air-In/Cable1 input switch. No harmonic retry (out of VHF scope).
+        True iff PLL locked."""
+        lo = rf_hz - self.if_hz if self.sideband_low else rf_hz + self.if_hz
+        self.set_sideband(self.sideband_low)   # keep 0x07[7] matched to the LO
         self._set_mux(lo)
         ok = self._set_pll(lo)
         self._wr_mask(0x05, 0x00 if rf_hz > 345_000_000 else 0x60, 0x60)  # Air/Cable
         return ok
+
+    def set_sideband(self, low):
+        """Select mixer sideband / injection side via 0x07 bit 7.
+        low=False -> bit7=0 = high-side (LO above RF), the chip/init default;
+        low=True  -> bit7=1 = low-side  (LO below RF).
+        Polarity follows the r82xx lineage (tuner_r82xx_explained.md:94);
+        BENCH-CONFIRM on the RX888 mk2. set_mixer_gain (mask 0x0F) and
+        set_mixer_agc (mask 0x10) leave bit 7 untouched, so this persists."""
+        self._wr_mask(0x07, 0x80 if low else 0x00, 0x80)
+
+    def spectrum_inverted(self):
+        """True if the current injection side inverts the spectrum at the IF.
+        High-side (LO=RF+IF) inverts; low-side (LO=RF-IF) does not."""
+        return not self.sideband_low
 
     def _set_mux(self, lo):
         mhz = lo // 1_000_000

--- a/vhf/vhf_fm_howto.md
+++ b/vhf/vhf_fm_howto.md
@@ -145,7 +145,26 @@ fine; or just stop the container.)
 | Audio silent in `monitor` | Host has no `/dev/snd`, or `fm-pcm.local` not resolving. Check `docker logs ka9q-radio` for "Established under name". |
 | It was working, then went dead after I toggled dither/rand in ka9q | radiod rewrote the whole GPIO word and cleared `VHF_EN`. Re-run `python3 vhf/vhf_tune.py <freq> --persist`. Don't toggle dither/rand during VHF use. |
 | First `--vhf` start is slow | One-time FFTW wisdom generation for the 384 kHz channel. Cached after. Set `FFTW_RIGOR=estimate` for an instant (slower-runtime) build. |
-| Stereo/RDS won't decode | High-side LO (`LO = RF + IF`) inverts the spectrum. Mono FM audio is unaffected; stereo subcarriers may not lock. |
+| Stereo/RDS won't decode | High-side LO (`LO = RF + IF`, the default) inverts the spectrum. Mono FM audio is unaffected; stereo subcarriers may not lock. Fix: in the TUI press `s` to switch to **low-side** injection (`LO = RF − IF`), which yields a **non-inverted** spectrum — or tell ka9q-radio the input is inverted (see below). Trade-off: low-side moves the image to `RF − 2·IF` (~9.14 MHz below), so tracking-filter image rejection differs. |
+
+## Injection side and spectral inversion
+
+The R828D mixes to a fixed IF (4.57 MHz). The TUI defaults to **high-side**
+injection (`LO = RF + IF`), which flips the spectrum at the IF; the `s` key
+switches to **low-side** (`LO = RF − IF`), which does not. The tuner stays
+internally correct either way — pressing `s` reprograms the mixer sideband bit
+(`0x07[7]`) in lockstep with the LO and recalibrates the channel filter — but
+the ADC stream that ka9q-radio receives is inverted only for high-side.
+
+There is **no automatic signalling** of the side to ka9q-radio: the TUI drives
+the tuner over EP0 while `radiod` streams the ADC in a separate process, with
+no shared metadata channel. So you match them by hand:
+
+- The TUI shows the live state on the Bandwidth line — `LO+ INVERTED`
+  (high-side) or `LO- normal` (low-side).
+- For **high-side**, tell `radiod` the front end is inverted so demods see an
+  upright spectrum; for **low-side**, leave inversion off. (Mono FM doesn't
+  care; stereo/RDS does.)
 
 ## Reference
 
@@ -155,7 +174,7 @@ fine; or just stop the container.)
 | Launcher | `./docker/ka9q-radio/ka9q.sh start --vhf` |
 | Tuner (TUI, preferred) | `python3 vhf/vhf_fm_radio.py` |
 | Tuner (CLI) | `python3 vhf/vhf_tune.py <fm_hz> --persist` |
-| Receiver park frequency | 4.570 MHz (`IF_CARRIER`); `LO = RF + 4.57 MHz` |
+| Receiver park frequency | 4.570 MHz (`IF_CARRIER`); `LO = RF + 4.57 MHz` (high-side default; `s` toggles low-side `LO = RF − 4.57 MHz`) |
 | Tuner reference (CLKB) | 16 MHz |
 | ADC sample rate | 64.8 MHz (`samprate = 64m8`) |
 | Stream name | `fm-pcm.local` |

--- a/vhf/vhf_fm_radio.py
+++ b/vhf/vhf_fm_radio.py
@@ -67,6 +67,7 @@ HELP_TEXT = """\
 [dim]e[/]  toggle FILTER_EXT   [dim]w[/]  toggle FLT_EXT_WIDEST
 [dim]i / I[/]  IF offset \u00b1100 kHz (probe filter edges)
 [dim]0[/]  reset IF offset     [dim]r[/]  toggle ref 16/32 MHz
+[dim]s[/]  toggle LO side (high/low injection; low = non-inverted)
 [dim]p / P[/]  cal park \u00b110 MHz (probe filter corner vs park)
 [dim]q[/]  quit"""
 
@@ -131,6 +132,7 @@ class VHFRadioApp(App):
         self._if_offset = 0         # IF probe offset from nominal (Hz)
         self._cal_code = None       # FILT_CODE from calibrate_filter()
         self._cal_park = 100_100_000  # cal PLL park freq (non-round → sdm≠0)
+        self._sideband_low = False  # False = high-side (LO=RF+IF); True = low-side
         self._status_msg = ""
 
     def compose(self) -> ComposeResult:
@@ -228,9 +230,11 @@ class VHFRadioApp(App):
         ref_mhz = self._ref_hz // 1_000_000
         ref_str = (f"  [cyan]ref {ref_mhz}M[/]"
                    if ref_mhz != 16 else f"  ref {ref_mhz}M")
+        side_str = ("  [cyan]LO- normal[/]" if self._sideband_low
+                    else "  LO+ [yellow]INVERTED[/]")
         self.query_one("#bw", Static).update(
             f"  Bandwidth   {bw_str}"
-            f"    IF {actual_if / 1e6:.3f} MHz{off_str}{ref_str}")
+            f"    IF {actual_if / 1e6:.3f} MHz{off_str}{ref_str}{side_str}")
 
         def bar(label, val, agc=False, max_val=15):
             filled = "\u2588" * val + "\u2591" * (max_val - val)
@@ -329,6 +333,8 @@ class VHFRadioApp(App):
             self._reset_if_offset()
         elif char == "r":
             self._toggle_ref()
+        elif char == "s":
+            self._toggle_sideband()
         elif char == "p":
             self._nudge_cal_park(10_000_000)
         elif char == "P":
@@ -416,6 +422,20 @@ class VHFRadioApp(App):
         self._locked = self._rx.r828d_set_freq(int(self._freq_hz))
         cal_str = f" cal={self._cal_code}" if self._cal_code is not None else " cal=FAIL"
         self._status_msg = f"[cyan]Ref \u2192 {self._ref_hz // 1_000_000} MHz{cal_str}[/]"
+        self._update_display()
+
+    def _toggle_sideband(self) -> None:
+        """Toggle LO injection side (high ⇄ low), reprogram the mixer sideband
+        bit in lockstep with the LO, recalibrate the filter, and retune.
+        Low-side yields a non-inverted spectrum; high-side inverts it."""
+        self._sideband_low = not self._sideband_low
+        self._rx.sideband_low = self._sideband_low
+        self._cal_code = self._rx.calibrate_filter(self._cal_park)
+        self._locked = self._rx.r828d_set_freq(int(self._freq_hz))
+        side = "low (LO−IF)" if self._sideband_low else "high (LO+IF)"
+        spec = "normal" if self._sideband_low else "INVERTED"
+        cal_str = f" cal={self._cal_code}" if self._cal_code is not None else " cal=FAIL"
+        self._status_msg = f"[cyan]Injection → {side}, spectrum {spec}{cal_str}[/]"
         self._update_display()
 
     def _toggle_chan_filter(self) -> None:


### PR DESCRIPTION
## Summary

Adds an operator-selectable **LO injection side** to the R828D VHF tuner path, toggleable live from the TUI. The driver defaults to the existing **high-side** behavior (`LO = RF + IF`), so there is **zero behavior change until the new key is pressed**. Low-side (`LO = RF − IF`) yields a **non-inverted** spectrum — the fix for the long-standing stereo/RDS inversion caveat — at the cost of moving the image to `RF − 2·IF`.

> Base is `claude/return-vhf-tuner` (this branch = that branch + these two commits), so the diff shows only the injection-side change. None of the four `.github/PULL_REQUEST_TEMPLATE/` templates applies: this is host-tooling (`vhf/`) code + docs, not `SDDC_FX3/` firmware and not docs-only.

## Changes

**`vhf/rx888_vhf.py`**
- New `RX888.sideband_low` state (default `False` = high-side).
- New `set_sideband(low)` writing the mixer sideband bit `0x07[7]`; masked so gain/AGC writes never disturb it.
- `r828d_set_freq()` branches the LO (`RF − IF` for low-side) **and** writes the sideband bit in the same call, keeping the LO formula and the image-reject mixer permanently in lockstep.
- New `spectrum_inverted()` helper.

**`vhf/vhf_fm_radio.py`**
- New `s` key → `_toggle_sideband()` (set side → recal filter → retune), mirroring the existing ref toggle.
- Bandwidth/IF line shows `LO+ INVERTED` / `LO- normal`; help text updated.

**`vhf/vhf_fm_howto.md`**, **`docs/sideband-selection-plan.md`**
- Reworked the stereo/RDS caveat to point at `s`; new "Injection side and spectral inversion" section (including the honest note that there's no auto-signalling to `radiod` — separate process, no shared metadata — so the side is matched by hand); the approved implementation plan.

## Correctness

The LO formula and `0x07[7]` are written together in `r828d_set_freq`, so they can never desync — that lockstep is the entire correctness requirement for an image-reject mixer.

⚠️ **Bench confirmation needed:** the `0x07[7]` polarity is derived from the r82xx lineage (`tuner_r82xx_explained.md:94`), not verified on hardware. The code comment and the plan's validation steps flag this, matching the repo's "bench-confirmed" convention.

## Validation (requires RX888 mk2)

1. Tune a strong local FM station; confirm `● LOCKED`, audio, display `LO+ INVERTED`.
2. Press `s` → log shows fresh `LO=… lock=YES` with LO ≈9.14 MHz lower; display flips to `LO- normal`.
3. In ka9q-radio, station decodes **without** the host inversion setting; stereo/RDS tracks the side.
4. Press `s` again → back to high-side.
5. I2C read-back of `0x07[7]` matches the displayed side.

## Regression

- Default path is byte-identical: `sideband_low=False` → `LO = RF+IF` and `set_sideband(False)` rewrites `0x07[7]=0`, which the init array (`0x07=0x70`) already set.
- `python3 -m py_compile` passes on both scripts.
- `s` persists across `r`/`b` (those paths don't touch `0x07[7]`); `q` standby (`0x07=0x3A`) still clears the bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Uq9YSexbuJQh6JkcSNz7C

---
_Generated by [Claude Code](https://claude.ai/code/session_012Uq9YSexbuJQh6JkcSNz7C)_